### PR TITLE
refactor: retire les commentaires non essentiels du code

### DIFF
--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/api/OperatorApplicationsResource.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/api/OperatorApplicationsResource.kt
@@ -31,12 +31,6 @@ data class OperatorApplicationRequest(
     val logoUrl: String? = null,
 )
 
-/**
- * Duplication des endpoints applications pour l'opérateur k8s : auth par clé partagée
- * (voir OperatorApiKeyFilter) au lieu d'OIDC, JSON au lieu de multipart (le logo est déclaré
- * par URL et téléchargé côté serveur, pas uploadé).
- * Exclu du contrat OpenAPI consommé par Orval (mp.openapi.scan.exclude.classes).
- */
 @Path("/api/operator/applications")
 @OperatorApiKeyProtected
 @Consumes(MediaType.APPLICATION_JSON)
@@ -80,8 +74,6 @@ class OperatorApplicationsResource(
             Response.status(Response.Status.NOT_FOUND).build()
         }
 
-    // Contrat déclaratif : logoUrl absent = pas de logo désiré, le use case supprime alors
-    // un logo précédemment téléchargé (mais préserve un upload manuel)
     private fun OperatorApplicationRequest.toInput() =
         ApplicationInput(
             name, category, description, url, requiresVpn, managedBy, externalId,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/domain/ApplicationInput.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/domain/ApplicationInput.kt
@@ -6,16 +6,12 @@ const val MAX_LOGO_SIZE_BYTES = 1024L * 1024L
 data class LogoUpload(val bytes: ByteArray, val contentType: String?)
 
 sealed interface LogoChange {
-    /** Formulaire admin sans fichier : le logo existant est conservé tel quel */
     data object Keep : LogoChange
 
-    /** Upload manuel : remplace le logo et efface la source URL (le déclaratif reprendra la main au prochain drift) */
     data class Upload(val logo: LogoUpload) : LogoChange
 
-    /** Source déclarée par l'opérateur : téléchargée seulement si l'URL diffère de celle déjà stockée */
     data class FromUrl(val url: String) : LogoChange
 
-    /** Plus de source déclarée : supprime le logo seulement s'il provenait d'une URL (un upload manuel survit) */
     data object Remove : LogoChange
 }
 

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/domain/ports/LogoFetcher.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/domain/ports/LogoFetcher.kt
@@ -3,6 +3,5 @@ package org.hoohoot.homelab.manager.applications.domain.ports
 import org.hoohoot.homelab.manager.applications.domain.LogoUpload
 
 interface LogoFetcher {
-    /** null si le téléchargement échoue ou si l'image est invalide (type/taille) — loggé côté adapter */
     suspend fun fetch(url: String): LogoUpload?
 }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/domain/usecases/CreateApplication.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/domain/usecases/CreateApplication.kt
@@ -26,8 +26,6 @@ class CreateApplication(
                 entity.logoContentType = change.logo.contentType
             }
 
-            // Échec de téléchargement : l'app est créée sans logo ni source, le prochain sweep
-            // de l'opérateur verra le drift et retentera
             is LogoChange.FromUrl -> logoFetcher.fetch(change.url)?.let {
                 entity.logo = it.bytes
                 entity.logoContentType = it.contentType

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/domain/usecases/UpdateApplication.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/domain/usecases/UpdateApplication.kt
@@ -15,8 +15,6 @@ class UpdateApplication(
     private val logoFetcher: LogoFetcher,
 ) {
     suspend operator fun invoke(id: UUID, input: ApplicationInput): ApplicationEntity? {
-        // Le fetch est suspend, la mutation transactionnelle ne l'est pas : on télécharge avant,
-        // et seulement si la source a changé (un drift sur un autre champ ne re-télécharge pas)
         val change = input.logo
         val fetched = if (change is LogoChange.FromUrl && change.url != applications.findById(id)?.logoSourceUrl) {
             logoFetcher.fetch(change.url)
@@ -35,8 +33,6 @@ class UpdateApplication(
                     entity.logoSourceUrl = null
                 }
 
-                // Échec de téléchargement (fetched null alors que la source a changé) : on garde
-                // l'ancien logo et l'ancienne source, le prochain sweep de l'opérateur retentera
                 is LogoChange.FromUrl -> fetched?.let {
                     entity.logo = it.bytes
                     entity.logoContentType = it.contentType

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/infra/LogoDownloadClient.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/applications/infra/LogoDownloadClient.kt
@@ -10,11 +10,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
 import org.jboss.resteasy.reactive.RestResponse
 import java.time.temporal.ChronoUnit
 
-/**
- * Les logos sont servis depuis des URLs absolues variables : @Url remplace la base à chaque appel.
- * RestResponse plutôt que Response : l'entité est lue de façon non bloquante (readEntity sur
- * l'event loop lève BlockingNotAllowedException).
- */
+// RestResponse (pas Response) : readEntity sur l'event loop lèverait BlockingNotAllowedException
 @RegisterRestClient(configKey = "logo-download")
 @Retry(maxRetries = 2, delay = 500, jitter = 250, retryOn = [ProcessingException::class, TimeoutException::class])
 @Timeout(value = 30, unit = ChronoUnit.SECONDS)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/api/AdminCleanupResource.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/api/AdminCleanupResource.kt
@@ -68,10 +68,6 @@ class AdminCleanupResource(
         getCampaign(id)?.let { it.campaign.toDetailsDto(it.candidates) }
             ?: throw NotFoundException()
 
-    /**
-     * Le scan charge les bibliothèques Radarr/Sonarr/Jellyfin : trop long pour la requête,
-     * il part en arrière-plan (202). Le front suit l'apparition de la campagne via GET /campaign.
-     */
     @POST
     @Path("/campaigns/scan")
     @APIResponseSchema(value = ScanStartedDto::class, responseCode = "202")
@@ -106,8 +102,6 @@ class AdminCleanupResource(
     suspend fun deleteProtection(@PathParam("id") id: UUID): Response =
         unprotectMedia(id, Accessor.Admin).toResponse()
 
-    // Le scan survit à la requête : coroutine sur un contexte Vertx duplé et marqué safe,
-    // condition pour que Hibernate Reactive accepte d'y ouvrir des sessions
     private fun launchInBackground(block: suspend () -> Unit) {
         val context = VertxContext.getOrCreateDuplicatedContext(vertx)
         VertxContextSafetyToggle.setContextSafe(context, true)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/api/CleanupDtos.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/api/CleanupDtos.kt
@@ -42,7 +42,6 @@ data class CleanupCampaignDetailsDto(
     val freeBytesAtStart: Long,
     val targetBytesToFree: Long,
     val freedBytes: Long,
-    // OffsetDateTime : le front calcule un compte à rebours, l'offset lève l'ambiguïté de fuseau
     val graceEndsAt: OffsetDateTime,
     val createdAt: LocalDateTime,
     val completedAt: LocalDateTime?,
@@ -150,7 +149,6 @@ data class CleanupSuggestionDto(
     val sizeBytes: Long,
     val suggestedBy: String,
     val status: String,
-    // OffsetDateTime : le front calcule un compte à rebours, l'offset lève l'ambiguïté de fuseau
     val deleteAfter: OffsetDateTime,
     val vetoedBy: String?,
     val freedBytes: Long?,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/api/CleanupResource.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/api/CleanupResource.kt
@@ -44,7 +44,6 @@ class CleanupResource(
     private val suggestDeletion: SuggestDeletion,
 ) {
     companion object {
-        // Les issues récentes (veto, suppression…) restent visibles quelques jours dans l'UI
         private const val RECENT_SUGGESTIONS_DAYS = 7L
     }
 

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/bot/GardeMatrixCommand.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/bot/GardeMatrixCommand.kt
@@ -41,7 +41,6 @@ class GardeMatrixCommand(
 
         Log.info("Cleanup: veto requested by ${sender.localpart} for '$parameters'")
 
-        // Les commandes bot tournent sur les dispatchers trixnity : Panache exige un contexte Vertx safe
         val result = runOnSafeVertxContext(vertx) { vetoByTitle(parameters, sender.localpart) }
 
         when (result) {

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/bot/SuggestionVetoReactionHandler.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/bot/SuggestionVetoReactionHandler.kt
@@ -12,8 +12,6 @@ import org.hoohoot.homelab.manager.shared.matrix.bot.MatrixBotSession
 import org.hoohoot.homelab.manager.shared.matrix.bot.reactions.ReactionBotHandler
 import org.hoohoot.homelab.manager.shared.vertx.runOnSafeVertxContext
 
-// Une réaction ❌ sur l'annonce d'une suggestion vaut veto immédiat : l'issue est
-// annoncée dans le chat sans attendre l'échéance
 @ApplicationScoped
 class SuggestionVetoReactionHandler(
     private val vetoSuggestionByReaction: VetoSuggestionByReaction,
@@ -29,7 +27,6 @@ class SuggestionVetoReactionHandler(
     ) {
         if (!MatrixVetoReactionsAdapter.isVetoEmoji(key)) return
 
-        // Les handlers bot tournent sur les dispatchers trixnity : Panache exige un contexte Vertx safe
         val vetoed = runOnSafeVertxContext(vertx) {
             vetoSuggestionByReaction(targetEventId.full, sender.localpart)
         }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/CandidateScorer.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/CandidateScorer.kt
@@ -4,16 +4,11 @@ import java.time.Duration
 import java.time.LocalDateTime
 import kotlin.math.roundToInt
 
-/**
- * Scoring pur d'un candidat au nettoyage : plus le score est haut, plus le média est supprimable.
- * Le breakdown complet est retourné pour rester explicable dans l'UI et dans l'annonce Matrix.
- */
 class CandidateScorer(
     private val config: CleanupConfig,
     private val now: LocalDateTime,
 ) {
     companion object {
-        // Un média non corrélé à Jellyfin n'est peut-être juste pas reconnu : prudence
         const val UNCORRELATED_CAP = 0.7
         const val REQUESTER_ACTIVITY_REF_DAYS = 180L
     }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/CleanupModels.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/CleanupModels.kt
@@ -2,7 +2,6 @@ package org.hoohoot.homelab.manager.cleanup.domain
 
 import java.time.LocalDateTime
 
-// Configuration effective du nettoyage, chargée des properties (cleanup.*)
 data class CleanupConfig(
     val diskPath: String,
     val thresholdFreeBytes: Long,
@@ -64,7 +63,6 @@ data class CleanupSeason(
     val previousAiring: LocalDateTime?,
 )
 
-// Entrée de la bibliothèque Jellyfin, porteuse des provider ids partagés avec Radarr/Sonarr
 data class JellyfinLibraryEntry(
     val itemId: String,
     val name: String,
@@ -77,7 +75,6 @@ data class JellyfinLibraryEntry(
 
 enum class JellyfinEntryType { MOVIE, SERIES }
 
-// Agrégat de visionnage d'un film (une ligne par item Jellyfin)
 data class MovieWatchAggregate(
     val itemId: String,
     val itemName: String,
@@ -86,7 +83,6 @@ data class MovieWatchAggregate(
     val lastInProgressAt: LocalDateTime?,
 )
 
-// Agrégat de visionnage d'une saison (une ligne par saison Jellyfin visionnée)
 data class SeasonWatchAggregate(
     val seriesId: String?,
     val seriesName: String?,
@@ -98,7 +94,6 @@ data class SeasonWatchAggregate(
 
 enum class Correlation { PROVIDER_ID, TITLE, NONE }
 
-// Visionnage corrélé d'un média *arr : ce que le scoring consomme
 data class CorrelatedWatch(
     val correlation: Correlation,
     val lastWatchedAt: LocalDateTime?,
@@ -125,7 +120,6 @@ sealed interface Evaluation {
     data class Scored(val breakdown: ScoreBreakdown) : Evaluation
 }
 
-// Objet racine JSONB (cleanup_candidate.score_breakdown) : jamais une List à la racine
 data class ScoreBreakdown(
     val total: Double = 0.0,
     val components: List<ScoreComponent> = emptyList(),
@@ -149,7 +143,6 @@ data class ScoreInputs(
     val correlation: String = Correlation.NONE.name,
 )
 
-// Objet racine JSONB (cleanup_campaign.state)
 data class CampaignState(
     val executionSummary: ExecutionSummary? = null,
 )
@@ -175,7 +168,6 @@ sealed interface DeleteOutcome {
     data class Failed(val reason: String) : DeleteOutcome
 }
 
-// Qui agit sur une ressource cleanup : l'utilisateur (limité aux siennes) ou un admin
 sealed interface Accessor {
     data class User(val username: String) : Accessor
     data object Admin : Accessor

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/MediaCorrelator.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/MediaCorrelator.kt
@@ -2,12 +2,6 @@ package org.hoohoot.homelab.manager.cleanup.domain
 
 import java.time.LocalDateTime
 
-/**
- * Corrèle les médias Radarr/Sonarr avec la bibliothèque et l'historique de visionnage Jellyfin.
- * Priorité aux provider ids (TMDB/IMDB/TVDB), fallback sur le titre normalisé ; en cas
- * d'ambiguïté le média est traité comme non corrélé (le scoring plafonne alors sa composante
- * « jamais visionné » par prudence).
- */
 class MediaCorrelator(
     jellyfinEntries: List<JellyfinLibraryEntry>,
     movieWatches: List<MovieWatchAggregate>,
@@ -46,7 +40,6 @@ class MediaCorrelator(
             return movieWatchesByItemId[titleEntry.itemId].toCorrelated(Correlation.TITLE)
         }
 
-        // Le film n'est plus (ou pas) dans Jellyfin : on tente encore l'historique par nom d'item
         val watchesByName = movieWatchesByTitle[Titles.normalize(movie.title)].orEmpty()
         if (watchesByName.map { it.itemId }.distinct().size == 1) {
             return watchesByName.first().toCorrelated(Correlation.TITLE)
@@ -69,7 +62,6 @@ class MediaCorrelator(
         )
     }
 
-    // Dernier visionnage toutes saisons confondues — garde-fou « rewatch en cours »
     fun seriesLastWatchedAt(series: CleanupSeries): LocalDateTime? =
         seasonWatchesOf(series).second.maxOfOrNull { it.lastWatchedAt }
 
@@ -93,7 +85,6 @@ class MediaCorrelator(
         return Correlation.NONE to emptyList()
     }
 
-    // Match par titre normalisé, départagé par l'année (±1) ; plusieurs homonymes -> non corrélé
     private fun uniqueEntryByTitle(
         entriesByTitle: Map<String, List<JellyfinLibraryEntry>>,
         title: String,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/TitleMatcher.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/TitleMatcher.kt
@@ -12,17 +12,11 @@ data class MatchableCandidate(
 )
 
 sealed interface TitleMatch {
-    // Tous les candidats d'un même média : un film, ou les saisons candidates d'une même série
     data class Matched(val candidates: List<MatchableCandidate>) : TitleMatch
     data class Ambiguous(val titles: List<String>) : TitleMatch
     data object NoMatch : TitleMatch
 }
 
-/**
- * Matching du titre donné au bot (`!johnny garde <titre>`) contre les candidats de la campagne
- * active : égalité exacte > préfixe > contient, sur titres normalisés. Plusieurs médias distincts
- * dans le meilleur palier -> ambigu, l'utilisateur doit préciser.
- */
 class TitleMatcher {
     fun match(query: String, candidates: List<MatchableCandidate>): TitleMatch {
         val normalizedQuery = Titles.normalize(query)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/Titles.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/Titles.kt
@@ -2,7 +2,6 @@ package org.hoohoot.homelab.manager.cleanup.domain
 
 import java.text.Normalizer
 
-// Normalisation partagée corrélation Jellyfin / matching bot : accents, casse, ponctuation
 object Titles {
     private val diacritics = Regex("\\p{M}")
     private val nonAlphanumeric = Regex("[^a-z0-9]+")

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/ports/CleanupNotifier.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/ports/CleanupNotifier.kt
@@ -6,7 +6,6 @@ import org.hoohoot.homelab.manager.cleanup.infra.CleanupCandidateEntity
 import org.hoohoot.homelab.manager.cleanup.infra.CleanupSuggestionEntity
 
 interface CleanupNotifier {
-    // Retourne l'event id Matrix de l'annonce, null si l'envoi a échoué (best-effort)
     suspend fun announceCampaign(
         campaign: CleanupCampaignEntity,
         candidates: List<CleanupCandidateEntity>,
@@ -16,13 +15,11 @@ interface CleanupNotifier {
 
     suspend fun announceCancellation(campaign: CleanupCampaignEntity)
 
-    // Retourne l'event id Matrix de l'annonce, null si l'envoi a échoué (best-effort)
     suspend fun announceSuggestion(suggestion: CleanupSuggestionEntity): String?
 
     suspend fun announceSuggestionOutcome(suggestion: CleanupSuggestionEntity)
 }
 
 interface SuggestionVetoes {
-    // Utilisateurs (localparts) ayant réagi ❌ à l'annonce d'une suggestion
     suspend fun vetoers(announcementEventId: String): List<String>
 }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/ports/CleanupStores.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/ports/CleanupStores.kt
@@ -28,7 +28,6 @@ interface Candidates {
 interface Suggestions {
     suspend fun listPending(): List<CleanupSuggestionEntity>
 
-    // Suggestions en attente + issues récentes, pour l'affichage
     suspend fun listRecent(resolvedSince: LocalDateTime): List<CleanupSuggestionEntity>
     suspend fun listDue(now: LocalDateTime): List<CleanupSuggestionEntity>
     suspend fun find(id: UUID): CleanupSuggestionEntity?
@@ -45,7 +44,6 @@ interface Protections {
 }
 
 interface ActiveProblems {
-    // Médias avec un problem_workflow non terminal : jamais candidats à la suppression
     suspend fun activeMediaIds(): ActiveProblemIds
 }
 

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/ports/DiskSpaceGauge.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/ports/DiskSpaceGauge.kt
@@ -1,10 +1,8 @@
 package org.hoohoot.homelab.manager.cleanup.domain.ports
 
 interface DiskSpaceGauge {
-    // Espace libre d'après le dernier snapshot stats (rafraîchi toutes les 15 min)
     suspend fun snapshotFree(path: String): Long?
 
-    // Espace libre en direct (GET /diskspace Radarr) — re-check juste avant d'exécuter les suppressions
     suspend fun liveFree(path: String): Long?
 
     suspend fun knownPaths(): List<String>

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/ports/MediaCatalogs.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/ports/MediaCatalogs.kt
@@ -13,13 +13,10 @@ interface MovieCatalog {
 interface SeriesCatalog {
     suspend fun allSeries(): List<CleanupSeries>
 
-    // Date du dernier episodefile importé par saison — un appel Sonarr par série, à réserver
-    // aux séries déjà pré-filtrées
     suspend fun seasonDownloadDates(sonarrSeriesId: Int): Map<Int, LocalDateTime>
 }
 
 interface MovieEraser {
-    // sizeBytes : taille connue au scan, reprise dans Deleted (le DELETE Radarr ne renvoie rien)
     suspend fun deleteMovie(radarrMovieId: Int, sizeBytes: Long): DeleteOutcome
 }
 
@@ -28,7 +25,6 @@ interface SeasonEraser {
 }
 
 interface SeriesEraser {
-    // sizeBytes : taille connue au moment de la suggestion (le DELETE Sonarr ne renvoie rien)
     suspend fun deleteSeries(sonarrSeriesId: Int, sizeBytes: Long): DeleteOutcome
 }
 

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/ports/PlaybackHistory.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/ports/PlaybackHistory.kt
@@ -9,11 +9,9 @@ interface PlaybackHistory {
 
     suspend fun seasonWatchAggregates(): List<SeasonWatchAggregate>
 
-    // Dernière session de chaque utilisateur, clé user_name en minuscules
     suspend fun userLastActivity(): Map<String, LocalDateTime>
 }
 
 interface MemberStatuses {
-    // username (minuscules) -> membre actif
     suspend fun memberStatuses(): Map<String, Boolean>
 }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/ExecuteDueCampaigns.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/ExecuteDueCampaigns.kt
@@ -37,7 +37,6 @@ class ExecuteDueCampaigns(
         val proposed = all.filter { it.status == CleanupCandidateEntity.STATUS_PROPOSED }
             .sortedByDescending { it.score }
 
-        // Re-check en direct : l'espace a pu se libérer pendant la période de grâce
         val liveFree = diskSpaceGauge.liveFree(campaign.diskPath) ?: diskSpaceGauge.snapshotFree(campaign.diskPath)
         val targetFreeBytes = campaign.freeBytesAtStart + campaign.targetBytesToFree
         val stillToFree = liveFree?.let { targetFreeBytes - it } ?: campaign.targetBytesToFree
@@ -56,7 +55,6 @@ class ExecuteDueCampaigns(
             }
 
             val candidateId = requireNotNull(candidate.id)
-            // Re-check juste avant suppression : un veto ou un problème a pu apparaître
             val fresh = candidates.find(candidateId) ?: continue
             if (fresh.status != CleanupCandidateEntity.STATUS_PROPOSED) continue
             if (protections.all().any { it.covers(fresh.radarrMovieId, fresh.sonarrSeriesId, fresh.seasonNumber) }) {
@@ -95,7 +93,6 @@ class ExecuteDueCampaigns(
         return complete(campaign, freedNow = freed, note = null)
     }
 
-    // Une erreur sur un candidat ne doit pas interrompre les suivants
     private suspend fun delete(candidate: CleanupCandidateEntity): DeleteOutcome = try {
         when (candidate.mediaKind) {
             CleanupCandidateEntity.KIND_MOVIE ->

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/ExecuteDueSuggestions.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/ExecuteDueSuggestions.kt
@@ -32,15 +32,12 @@ class ExecuteDueSuggestions(
     private suspend fun execute(suggestion: CleanupSuggestionEntity): CleanupSuggestionEntity? {
         val suggestionId = requireNotNull(suggestion.id)
 
-        // Sans annonce, personne n'a pu poser de veto : on ne supprime pas
         val announcementEventId = suggestion.announcementEventId
             ?: return finish(suggestionId) {
                 it.status = CleanupSuggestionEntity.STATUS_SKIPPED
                 it.failureReason = "l'annonce Matrix n'a jamais été envoyée, suppression annulée par prudence"
             }
 
-        // Le veto s'exprime en réaction ❌ sur l'annonce : lu à l'échéance, il survit aux redémarrages.
-        // Si Matrix est injoignable, on reporte plutôt que de supprimer sans avoir lu les vetos.
         val vetoer = try {
             vetoes.vetoers(announcementEventId).firstOrNull()
         } catch (exception: Exception) {
@@ -55,7 +52,6 @@ class ExecuteDueSuggestions(
             }
         }
 
-        // Re-check juste avant suppression : une protection ou un problème a pu apparaître
         if (protections.all().any {
                 it.blocksDeletionOf(suggestion.mediaKind, suggestion.radarrMovieId, suggestion.sonarrSeriesId, suggestion.seasonNumber)
             }
@@ -94,7 +90,6 @@ class ExecuteDueSuggestions(
         }
     }
 
-    // Une erreur sur une suggestion ne doit pas interrompre les suivantes
     private suspend fun delete(suggestion: CleanupSuggestionEntity): DeleteOutcome = try {
         when (suggestion.mediaKind) {
             CleanupSuggestionEntity.KIND_MOVIE ->

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/ProtectMedia.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/ProtectMedia.kt
@@ -20,7 +20,6 @@ data class ProtectionRequest(
     val seasonNumber: Int?,
 )
 
-// Protection proactive (liste blanche) : un média protégé ne sera jamais candidat au nettoyage
 @ApplicationScoped
 class ProtectMedia(
     private val protections: Protections,
@@ -82,7 +81,6 @@ class ProtectMedia(
         }
     }
 
-    // Cohérence : protéger un média couvert par la campagne active vaut veto immédiat
     private suspend fun protectMatchingCandidates(protection: CleanupProtectionEntity, username: String) {
         val campaign = campaigns.findActive() ?: return
         candidates.listByCampaign(requireNotNull(campaign.id))

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/RetryCandidate.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/RetryCandidate.kt
@@ -13,8 +13,6 @@ import org.hoohoot.homelab.manager.cleanup.infra.CleanupCandidateEntity
 import java.time.LocalDateTime
 import java.util.UUID
 
-// Rejoue la suppression d'un candidat FAILED (admin). La suppression *arr est idempotente :
-// ce qui a déjà été supprimé lors de la tentative précédente le reste.
 @ApplicationScoped
 class RetryCandidate(
     private val candidates: Candidates,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/ScanAndStartCampaign.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/ScanAndStartCampaign.kt
@@ -124,7 +124,6 @@ class ScanAndStartCampaign(
         val entities = selected.map { it.toEntity(campaign.id!!, now) }
         candidates.saveAll(entities)
 
-        // Annonce best-effort : un échec Matrix ne doit pas annuler la campagne
         try {
             val eventId = notifier.announceCampaign(campaign, entities)
             if (eventId != null) campaigns.update(campaign.id!!) { it.announcementEventId = eventId }
@@ -149,7 +148,6 @@ class ScanAndStartCampaign(
             if (series.sonarrSeriesId in problemIds) continue
             if (allProtections.any { it.covers(null, series.sonarrSeriesId, null) && it.mediaKind == CleanupProtectionEntity.KIND_SERIES }) continue
 
-            // Une série regardée récemment (toutes saisons confondues) est un rewatch potentiel
             val seriesLastWatched = correlator.seriesLastWatchedAt(series)
             if (seriesLastWatched != null &&
                 Duration.between(seriesLastWatched, now).toDays() < config.recentSeriesWatchDays
@@ -164,7 +162,6 @@ class ScanAndStartCampaign(
             }
             if (eligibleSeasons.isEmpty()) continue
 
-            // Un appel Sonarr par série, seulement pour celles qui ont passé les filtres
             val downloadDates = seriesCatalog.seasonDownloadDates(series.sonarrSeriesId)
 
             for (season in eligibleSeasons) {
@@ -178,8 +175,6 @@ class ScanAndStartCampaign(
         return proposals
     }
 
-    // Meilleurs scores d'abord, jusqu'à couvrir l'objectif d'espace (le candidat qui franchit
-    // l'objectif est inclus) dans la limite du plafond
     private fun selectProposals(
         proposals: List<Proposal>,
         targetToFree: Long,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/SearchProtectableMedia.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/SearchProtectableMedia.kt
@@ -7,7 +7,6 @@ import org.hoohoot.homelab.manager.cleanup.domain.Titles
 import org.hoohoot.homelab.manager.cleanup.domain.ports.MovieCatalog
 import org.hoohoot.homelab.manager.cleanup.domain.ports.SeriesCatalog
 
-// Les APIs *arr ne supportent pas de recherche : on filtre la bibliothèque côté backend
 @ApplicationScoped
 class SearchProtectableMedia(
     private val movieCatalog: MovieCatalog,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/SuggestDeletion.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/SuggestDeletion.kt
@@ -20,7 +20,6 @@ data class SuggestionRequest(
     val seasonNumber: Int?,
 )
 
-// Suggestion de suppression : annoncée sur Matrix, supprimée à l'échéance sauf veto ❌ en réaction
 @ApplicationScoped
 class SuggestDeletion(
     private val configStore: CleanupConfigStore,
@@ -59,7 +58,6 @@ class SuggestDeletion(
         suggestion.updatedAt = now
         val saved = suggestions.save(suggestion)
 
-        // Annonce best-effort : sans event id, l'exécution n'osera pas supprimer (aucun veto possible)
         try {
             val eventId = notifier.announceSuggestion(saved)
             if (eventId != null) suggestions.update(requireNotNull(saved.id)) { it.announcementEventId = eventId }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/VetoByTitle.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/VetoByTitle.kt
@@ -14,7 +14,6 @@ import org.hoohoot.homelab.manager.cleanup.infra.CleanupProtectionEntity
 import java.time.LocalDateTime
 import java.util.UUID
 
-// Veto par titre depuis le bot Matrix : `!johnny garde <titre>`
 @ApplicationScoped
 class VetoByTitle(
     private val campaigns: Campaigns,
@@ -61,7 +60,6 @@ class VetoByTitle(
             }
         }
 
-        // Un veto bot sur une série protège la série entière, pas seulement les saisons candidates
         val sample = entities.first()
         saveProtectionIfMissing(sample, username)
 

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/VetoCandidate.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/VetoCandidate.kt
@@ -28,7 +28,6 @@ class VetoCandidate(
             it.protectedAt = LocalDateTime.now()
         } ?: return VetoResult.NotFound
 
-        // Le veto vaut protection durable : le média ne sera plus jamais candidat
         saveProtectionIfMissing(updated, username)
 
         return VetoResult.Ok(updated)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/VetoSuggestionByReaction.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/domain/usecases/VetoSuggestionByReaction.kt
@@ -7,9 +7,6 @@ import org.hoohoot.homelab.manager.cleanup.domain.ports.Suggestions
 import org.hoohoot.homelab.manager.cleanup.infra.CleanupSuggestionEntity
 import java.time.LocalDateTime
 
-// Veto immédiat quand une réaction ❌ arrive sur l'annonce : retour direct dans le chat sans
-// attendre l'échéance. La lecture des réactions à l'échéance reste le filet de sécurité
-// (réactions posées pendant un redémarrage de l'app).
 @ApplicationScoped
 class VetoSuggestionByReaction(
     private val suggestions: Suggestions,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/ArrDates.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/ArrDates.kt
@@ -4,7 +4,6 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 
-// Les APIs *arr renvoient des instants ISO ; la base raisonne en UTC (cf. playback_session)
 internal fun String?.toUtcLocalDateTime(): LocalDateTime? = this?.let {
     runCatching { LocalDateTime.ofInstant(Instant.parse(it), ZoneOffset.UTC) }.getOrNull()
 }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/ArrDiskSpaceAdapter.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/ArrDiskSpaceAdapter.kt
@@ -19,7 +19,6 @@ class ArrDiskSpaceAdapter(
             .sortedByDescending { it.collectedAt }
             .firstNotNullOfOrNull { it.disks[path]?.freeBytes }
 
-    // Best-effort : en cas d'échec on retombera sur le snapshot
     override suspend fun liveFree(path: String): Long? = try {
         radarrRestClient.getDiskSpace().orEmpty().firstOrNull { it.path == path }?.freeSpace
     } catch (exception: Exception) {

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/CleanupProtectionEntity.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/CleanupProtectionEntity.kt
@@ -54,7 +54,6 @@ class CleanupProtectionEntity : PanacheEntityBase {
         const val SOURCE_PROACTIVE = "PROACTIVE"
     }
 
-    // Une protection SERIES couvre toutes les saisons de la série
     fun covers(radarrMovieId: Int?, sonarrSeriesId: Int?, seasonNumber: Int?): Boolean = when (mediaKind) {
         KIND_MOVIE -> radarrMovieId != null && this.radarrMovieId == radarrMovieId
         KIND_SERIES -> sonarrSeriesId != null && this.sonarrSeriesId == sonarrSeriesId
@@ -63,7 +62,6 @@ class CleanupProtectionEntity : PanacheEntityBase {
         else -> false
     }
 
-    // Supprimer une série entière emporterait ses saisons : la protection d'une seule saison suffit à bloquer
     fun blocksDeletionOf(mediaKind: String, radarrMovieId: Int?, sonarrSeriesId: Int?, seasonNumber: Int?): Boolean =
         covers(radarrMovieId, sonarrSeriesId, seasonNumber) ||
             (mediaKind == KIND_SERIES && sonarrSeriesId != null && this.sonarrSeriesId == sonarrSeriesId)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/CleanupSuggestionEntity.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/CleanupSuggestionEntity.kt
@@ -74,8 +74,6 @@ class CleanupSuggestionEntity : PanacheEntityBase {
 
     fun displayTitle(): String = if (seasonNumber != null) "$title — Saison $seasonNumber" else title
 
-    // Deux suggestions se chevauchent si l'une supprimerait (tout ou partie de) l'autre :
-    // une série entière chevauche chacune de ses saisons
     fun overlaps(mediaKind: String, radarrMovieId: Int?, sonarrSeriesId: Int?, seasonNumber: Int?): Boolean =
         when (this.mediaKind) {
             KIND_MOVIE -> mediaKind == KIND_MOVIE && radarrMovieId != null && this.radarrMovieId == radarrMovieId

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/MatrixVetoReactionsAdapter.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/MatrixVetoReactionsAdapter.kt
@@ -9,8 +9,6 @@ import jakarta.enterprise.context.ApplicationScoped
 import org.hoohoot.homelab.manager.cleanup.domain.ports.SuggestionVetoes
 import org.hoohoot.homelab.manager.shared.matrix.MatrixRoomProvider
 
-// Lit les réactions ❌ posées sur l'annonce via l'API relations : contrairement à une écoute
-// du sync du bot, rien n'est perdu si l'app redémarre pendant le délai de grâce
 @ApplicationScoped
 class MatrixVetoReactionsAdapter(
     private val matrixClient: MatrixClientServerApiClient,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/PlaybackHistoryAdapter.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/PlaybackHistoryAdapter.kt
@@ -10,7 +10,6 @@ import org.hoohoot.homelab.manager.cleanup.domain.ports.PlaybackHistory
 import org.hoohoot.homelab.manager.members.infra.MemberEntity
 import java.time.LocalDateTime
 
-// Agrégations SQL natives sur playback_session (timestamps UTC)
 @ApplicationScoped
 class PlaybackHistoryAdapter : PlaybackHistory, MemberStatuses {
 

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/ProblemWorkflowGuardAdapter.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/ProblemWorkflowGuardAdapter.kt
@@ -7,7 +7,6 @@ import org.hoohoot.homelab.manager.cleanup.domain.ActiveProblemIds
 import org.hoohoot.homelab.manager.cleanup.domain.ports.ActiveProblems
 import org.hoohoot.homelab.manager.problems.infra.ProblemWorkflowEntity
 
-// Un média avec un problème en cours de traitement ne doit jamais être supprimé
 @ApplicationScoped
 class ProblemWorkflowGuardAdapter : ActiveProblems {
     companion object {

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/RadarrCleanupAdapter.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/RadarrCleanupAdapter.kt
@@ -30,7 +30,6 @@ class RadarrCleanupAdapter(
         else DeleteOutcome.Failed("Radarr a répondu ${exception.response?.status} : ${exception.message}")
     }
 
-    // Best-effort : sans les tags on perd juste l'attribution du demandeur
     private suspend fun tagLabels(): Map<Int, String> = try {
         radarrRestClient.getTags().orEmpty()
             .mapNotNull { tag -> tag.id?.let { id -> tag.label?.let { id to it } } }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/SonarrCleanupAdapter.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/cleanup/infra/SonarrCleanupAdapter.kt
@@ -73,8 +73,6 @@ class SonarrCleanupAdapter(
     }
 
     override suspend fun deleteSeries(sonarrSeriesId: Int, sizeBytes: Long): DeleteOutcome {
-        // La taille a pu évoluer depuis la suggestion : mesure au moment de la suppression,
-        // repli sur la taille connue si Sonarr ne répond pas
         val freed = try {
             sonarrRestClient.getEpisodeFiles(sonarrSeriesId).orEmpty().sumOf { it.size ?: 0L }
         } catch (exception: Exception) {

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/domain/usecases/CreateMonthlyEnergyExpense.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/domain/usecases/CreateMonthlyEnergyExpense.kt
@@ -17,7 +17,6 @@ import java.time.YearMonth
 import java.time.ZoneId
 import java.util.UUID
 
-// Rattrapage limité : au-delà, la rétention Prometheus ne couvre plus les mesures
 private const val CATCH_UP_MONTHS = 3
 
 @ApplicationScoped
@@ -41,8 +40,6 @@ class CreateMonthlyEnergyExpense(
             val to = month.plusMonths(1).atDay(1).atStartOfDay(zone).toInstant()
             val averageWatts = energyMetrics.averagePowerWatts(from, to)
             if (averageWatts == null) {
-                // Seul le mois écoulé est bloquant : les mois plus anciens peuvent être
-                // sortis de la rétention Prometheus, inutile d'échouer indéfiniment dessus
                 if (offset == 1) {
                     throw IllegalStateException("Prometheus n'a renvoyé aucune mesure de puissance pour $period")
                 }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/domain/usecases/DeleteFinanceEntry.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/domain/usecases/DeleteFinanceEntry.kt
@@ -17,8 +17,6 @@ class DeleteFinanceEntry(
 ) {
     suspend operator fun invoke(id: UUID): EntryDeleteResult {
         val entity = financeEntries.findById(id) ?: return EntryDeleteResult.NotFound
-        // Supprimer une occurrence RECURRING la ferait régénérer par le job : on édite
-        // l'écriture ou on désactive la règle à la place
         if (entity.source == EntrySource.RECURRING) return EntryDeleteResult.RecurringForbidden
         financeEntries.delete(id)
         return EntryDeleteResult.Deleted

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/domain/usecases/GenerateRecurringEntries.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/domain/usecases/GenerateRecurringEntries.kt
@@ -16,9 +16,6 @@ class GenerateRecurringEntries(
     private val recurringRules: RecurringRules,
     private val financeEntries: FinanceEntries,
 ) {
-    // Rejouable à volonté : on re-parcourt toutes les périodes depuis start_date et
-    // saveIfAbsent ignore celles déjà matérialisées — le rattrapage après une longue
-    // extinction du serveur est donc automatique
     suspend operator fun invoke(today: LocalDate = LocalDate.now()): Int {
         var created = 0
         val currentPeriod = YearMonth.from(today)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/domain/usecases/GetCurrentEnergyStatus.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/domain/usecases/GetCurrentEnergyStatus.kt
@@ -9,7 +9,6 @@ import java.math.RoundingMode
 import java.time.Duration
 import java.time.Instant
 
-// Heures moyennes d'un mois (365,25 j / 12) pour projeter la conso mensuelle
 private const val HOURS_PER_MONTH = 730.5
 
 data class EnergyStatus(
@@ -27,7 +26,6 @@ class GetCurrentEnergyStatus(
     suspend operator fun invoke(): EnergyStatus {
         val kwhPrice = financeSettings.get().kwhPrice
 
-        // Prometheus indisponible ne doit pas casser la page Finances : on renvoie des nulls
         val currentWatts = runCatching { energyMetrics.currentPowerWatts() }
             .onFailure { Log.warn("Impossible de récupérer la puissance instantanée depuis Prometheus", it) }
             .getOrNull()

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/infra/FinanceEntryRepository.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/infra/FinanceEntryRepository.kt
@@ -119,8 +119,6 @@ class FinanceEntryRepository : FinanceEntries {
             entity.persist<FinanceEntryEntity>()
         }.awaitSuspending()
 
-    // Check-then-insert dans une même transaction : l'index unique (rule_id, period) /
-    // (period, source=ENERGY) reste le garde-fou en cas de course entre run planifié et manuel
     override suspend fun saveIfAbsent(entity: FinanceEntryEntity): Boolean =
         Panache.withTransaction {
             val existing = when {

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/infra/PrometheusEnergyMetrics.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/finances/infra/PrometheusEnergyMetrics.kt
@@ -7,8 +7,6 @@ import org.hoohoot.homelab.manager.shared.prometheus.PrometheusRestClient
 import java.time.Duration
 import java.time.Instant
 
-// Le max() agrège les séries dupliquées par le churn des pods snmp-exporter :
-// increase(upsHighPrecOutputEnergyUsage) serait cassé à chaque restart du pod
 private const val POWER_QUERY = "max(upsAdvOutputActivePower)"
 
 @ApplicationScoped

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/jobs/JobRunner.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/jobs/JobRunner.kt
@@ -12,12 +12,6 @@ data class JobRunResult(
     val error: String?,
 )
 
-/**
- * Runs a [ManagedJob] and records the execution in job_execution.
- * Both scheduled fires and manual runs go through here: the scheduler's
- * SuccessfulExecution/FailedExecution CDI events are not fired reliably
- * for suspend methods in dev mode, so recording is done in-line instead.
- */
 @ApplicationScoped
 class JobRunner(
     private val managedJobs: Instance<ManagedJob>,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/jobs/ManagedJob.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/jobs/ManagedJob.kt
@@ -1,10 +1,5 @@
 package org.hoohoot.homelab.manager.jobs
 
-/**
- * A scheduled job that can also be triggered manually from the admin UI.
- * [schedule] carries the human-readable planning expression because the
- * scheduler [io.quarkus.scheduler.Trigger] API does not expose it.
- */
 interface ManagedJob {
     val identity: String
     val displayName: String

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/jobsadmin/api/JobsResource.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/jobsadmin/api/JobsResource.kt
@@ -63,7 +63,6 @@ class JobsResource(
                     lastExecution = lastExecutions[trigger.id]?.toDto(),
                 )
             }
-        // Jobs à déclenchement manuel uniquement (ex : import Jellystat), inconnus du scheduler
         val manualOnly = jobRunner.all()
             .filter { job -> !isScheduled(job.identity) }
             .sortedBy { it.identity }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/library/infra/BazarrDownloadMapper.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/library/infra/BazarrDownloadMapper.kt
@@ -8,7 +8,6 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-// Format Bazarr : "1x02"
 private val BAZARR_EPISODE_NUMBER_REGEX = Regex("""(\d+)x(\d+)""")
 private val BAZARR_TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 
@@ -19,7 +18,6 @@ internal fun BazarrHistoryItem.toMediaDownload(isEpisode: Boolean): MediaDownloa
     if (action !in BazarrActions.DOWNLOAD_ACTIONS) return null
     val itemTitle = if (isEpisode) seriesTitle else title
     val downloadedAt = parseBazarrTimestamp()
-    // Sans id de record côté Bazarr, la clé de dédup est synthétique
     val mediaId = if (isEpisode) sonarrEpisodeId else radarrId
     if (itemTitle.isNullOrBlank() || downloadedAt == null || mediaId == null) {
         Log.warn("Skipping Bazarr history item '$itemTitle': missing title, media id or unparseable timestamp")

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/library/infra/DownloadsSyncService.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/library/infra/DownloadsSyncService.kt
@@ -28,7 +28,6 @@ class DownloadsSyncService(
     companion object {
         private const val DOWNLOAD_IMPORTED_EVENT_TYPE = "downloadFolderImported"
 
-        // Lidarr : un event par téléchargement d'album complet (vs trackFileImported, un par piste)
         private const val LIDARR_DOWNLOAD_IMPORTED_EVENT_TYPE = "downloadImported"
     }
 
@@ -137,7 +136,6 @@ class DownloadsSyncService(
     }
 
     private suspend fun sinceFor(source: String): LocalDateTime =
-        // Overlap d'1h sur le watermark : la dédup rend le refetch inoffensif
         mediaDownloadRepository.latestDownloadedAt(source)?.minusHours(1)
             ?: LocalDateTime.now().minusDays(backfillDays)
 

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/library/infra/MediaDownloadRepository.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/library/infra/MediaDownloadRepository.kt
@@ -35,7 +35,6 @@ class MediaDownloadRepository {
         }.awaitSuspending()?.downloadedAt
     }
 
-    // Insère uniquement les candidats absents (dédup sur source + externalId), renvoie le nombre inséré
     suspend fun saveNewDownloads(source: String, candidates: List<MediaDownloadEntity>): Int {
         if (candidates.isEmpty()) return 0
         return Panache.withTransaction {

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/library/infra/StatsService.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/library/infra/StatsService.kt
@@ -64,7 +64,6 @@ class StatsService(
     }
 
     fun merge(sources: List<SourceStats>): LibraryStats {
-        // Radarr and Sonarr usually report the same mounts: dedupe by path before summing
         val disks = sources.flatMap { it.disks }.distinctBy { it.path }
         val diskTotal = disks.sumOf { it.totalBytes }
         val diskFree = disks.sumOf { it.freeBytes }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/members/domain/usecases/SyncMembers.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/members/domain/usecases/SyncMembers.kt
@@ -13,8 +13,6 @@ class SyncMembers(
 ) {
     suspend operator fun invoke(): MemberSyncStats {
         val users = memberDirectory.fetchUsers()
-        // Un annuaire vide ressemble plus à un incident (mauvais groupe, token invalide)
-        // qu'à une communauté dissoute : on ne désactive pas tout le monde sur cette base
         check(users.isNotEmpty()) { "Authentik n'a renvoyé aucun utilisateur : synchronisation abandonnée" }
         val stats = members.syncFromDirectory(users)
         Log.info("Member sync: ${stats.created} créés, ${stats.updated} mis à jour, ${stats.deactivated} désactivés")

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/notifications/domain/NotificationMessage.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/notifications/domain/NotificationMessage.kt
@@ -5,10 +5,6 @@ data class NotificationMessage(
     val formattedBody: String,
 )
 
-/**
- * Rendu standard d'une notification : le texte brut joint les lignes par des sauts
- * de ligne, la version HTML les joint par des <br> sous un titre <h1>.
- */
 fun notificationMessage(header: String, lines: List<String>) = NotificationMessage(
     body = (listOf(header) + lines).joinToString("\n"),
     formattedBody = "<h1>$header</h1><p>${lines.joinToString("<br>")}</p>",

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/notifications/domain/usecases/NotifyEpisodeDownloaded.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/notifications/domain/usecases/NotifyEpisodeDownloaded.kt
@@ -35,7 +35,6 @@ class NotifyEpisodeDownloaded(
             ),
         )
 
-        // Les épisodes d'une même série sont regroupés dans un thread Matrix
         if (episode.seriesId != null) {
             val activeThread = threads.getThreadByMediaId(episode.seriesId, "series")
             val sentNotificationId = sender.send(NotificationRoom.MEDIA, message, activeThread)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/notifications/domain/usecases/NotifySubtitleDownloaded.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/notifications/domain/usecases/NotifySubtitleDownloaded.kt
@@ -32,7 +32,6 @@ class NotifySubtitleDownloaded(
             ),
         )
 
-        // Rattaché au thread du média correspondant quand il existe encore
         val existingThread = threads.getThreadByMediaKey(mediaKey(subtitle.mediaTitle, subtitle.year))
         sender.send(NotificationRoom.MEDIA, message, existingThread)
     }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/notifications/infra/giphy/GifDownloadClient.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/notifications/infra/giphy/GifDownloadClient.kt
@@ -9,7 +9,6 @@ import io.quarkus.rest.client.reactive.Url
 import jakarta.ws.rs.GET
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
 
-/** Les gifs sont servis depuis des URLs absolues variables : @Url remplace la base à chaque appel. */
 @RegisterRestClient(configKey = "giphy-media")
 @Retry(maxRetries = 2, delay = 500, jitter = 250, retryOn = [ProcessingException::class, TimeoutException::class])
 @Timeout(value = 30, unit = ChronoUnit.SECONDS)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/notifications/infra/stats/LocalViewingStats.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/notifications/infra/stats/LocalViewingStats.kt
@@ -22,11 +22,6 @@ import java.time.temporal.ChronoUnit
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 
-/**
- * Implémentation de ViewingStats sur l'historique local playback_session (module statistics),
- * en remplacement de l'API Jellystat. Chaque appel bascule sur un contexte Vertx safe :
- * les consommateurs (commandes du bot Matrix) tournent hors des dispatchers Quarkus.
- */
 @ApplicationScoped
 class LocalViewingStats(
     private val statisticsQueries: StatisticsQueries,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/api/AdminProblemsResource.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/api/AdminProblemsResource.kt
@@ -30,8 +30,6 @@ import org.hoohoot.homelab.manager.problems.domain.usecases.SelectSeries
 import org.hoohoot.homelab.manager.shared.api.conflict
 import java.util.UUID
 
-// Reprise d'un problème par un admin : mêmes use cases que la resource user,
-// mais avec Accessor.Admin (accès à tous les workflows, sans réassignation)
 @Path("/api/admin/problems")
 @Produces(MediaType.APPLICATION_JSON)
 @RolesAllowed("admin")

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/api/ProblemDtos.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/api/ProblemDtos.kt
@@ -112,7 +112,6 @@ internal fun ProblemWorkflowEntity.toAdminDto() = AdminProblemWorkflowDto(
     workflow = toDto(),
 )
 
-// L'étape courante est dérivée de l'état : reprendre un workflow = recharger son DTO
 private fun ProblemWorkflowEntity.currentStep(): String = when {
     status == ProblemWorkflowEntity.STATUS_ABANDONED -> "ABANDONED"
     status == ProblemWorkflowEntity.STATUS_COMPLETED -> "COMPLETED"

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/Accessor.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/Accessor.kt
@@ -1,6 +1,5 @@
 package org.hoohoot.homelab.manager.problems.domain
 
-// Qui agit sur un workflow : l'utilisateur (limité aux siens) ou un admin (tous, sans réassignation)
 sealed interface Accessor {
     data class User(val username: String) : Accessor
     data object Admin : Accessor

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/LibraryMovie.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/LibraryMovie.kt
@@ -8,6 +8,5 @@ data class LibraryMovie(
     val overview: String?,
     val currentQuality: String?,
     val currentLanguages: List<String> = emptyList(),
-    // Résolution voulue d'après le profil Radarr (ex : "1080"), pour recommander un upgrade
     val desiredResolution: String? = null,
 )

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/ports/Releases.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/ports/Releases.kt
@@ -5,6 +5,5 @@ import org.hoohoot.homelab.manager.problems.domain.Release
 interface Releases {
     suspend fun searchForMovie(radarrMovieId: Int): List<Release>
 
-    /** Lance le téléchargement d'une release ; jette si Radarr refuse. */
     suspend fun grab(guid: String, indexerId: Int)
 }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/usecases/DeleteWorkflow.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/usecases/DeleteWorkflow.kt
@@ -4,7 +4,6 @@ import jakarta.enterprise.context.ApplicationScoped
 import org.hoohoot.homelab.manager.problems.domain.ports.ProblemWorkflows
 import java.util.UUID
 
-// Admin uniquement : la resource user n'expose pas de suppression
 @ApplicationScoped
 class DeleteWorkflow(private val workflows: ProblemWorkflows) {
     suspend operator fun invoke(id: UUID): Boolean = workflows.delete(id)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/usecases/ListReleases.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/usecases/ListReleases.kt
@@ -20,7 +20,6 @@ class ListReleases(
     private val releases: Releases,
 ) {
     companion object {
-        // VOSTFR volontairement exclu : sous-titres, pas doublage
         private val VF_REGEX = Regex("""\b(MULTI|VF[FIQ2]?|FRENCH|TRUEFRENCH)\b""", RegexOption.IGNORE_CASE)
         private val RESOLUTION_REGEX = Regex("""(2160|1080|720|576|480)p""", RegexOption.IGNORE_CASE)
 
@@ -35,8 +34,6 @@ class ListReleases(
         if (workflow.problemType == null) {
             return ListReleasesResult.Conflict("a problem must be selected first")
         }
-        // Les règles Radarr rejettent la plupart des releases FR : on recommande nous-mêmes celles
-        // qui sont en torrent, à une bonne résolution, avec un tag VF/MULTI dans le titre.
         val desiredResolution = workflow.state.media?.desiredResolution?.toIntOrNull()
         val annotated = releases.searchForMovie(movieId)
             .map { AnnotatedRelease(it, it.isFrench(), it.isRecommended(desiredResolution)) }
@@ -51,9 +48,6 @@ class ListReleases(
     private fun Release.isFrench(): Boolean =
         languages.any { it.equals("French", ignoreCase = true) } || VF_REGEX.containsMatchIn(title)
 
-    // On recommande les torrents VF/MULTI à la résolution EXACTE demandée par le profil Radarr :
-    // ni en dessous (downgrade), ni au-dessus (ex : pas de 2160p quand le profil vise 1080p).
-    // Profil inconnu → permissif (on ne peut pas filtrer sur la résolution).
     private fun Release.isRecommended(desiredResolution: Int?): Boolean {
         if (!protocol.equals("torrent", ignoreCase = true)) return false
         if (!VF_REGEX.containsMatchIn(title)) return false

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/usecases/SearchLibrary.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/usecases/SearchLibrary.kt
@@ -16,7 +16,6 @@ class SearchLibrary(
         private const val MAX_SEARCH_RESULTS = 10
     }
 
-    // Les APIs *arr ne supportent pas de recherche : on filtre la bibliothèque côté backend
     suspend fun movies(query: String): List<LibraryMovie> =
         search(query, { movieLibrary.allMovies() }, { it.title })
 

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/usecases/SelectProblem.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/domain/usecases/SelectProblem.kt
@@ -22,7 +22,6 @@ class SelectProblem(
                 ProblemWorkflowEntity.PROBLEM_VO_SHOULD_BE_FRENCH,
                 ProblemWorkflowEntity.PROBLEM_OTHER,
             ),
-            // Pas de recherche de releases côté Sonarr : les séries passent par la déclaration libre
             ProblemWorkflowEntity.MEDIA_TYPE_TV to setOf(ProblemWorkflowEntity.PROBLEM_OTHER),
         )
     }
@@ -60,7 +59,6 @@ class SelectProblem(
             }
         } ?: return ProblemResult.NotFound
 
-        // Notifie le channel support quand le problème passe en REPORTED
         if (updated.status == ProblemWorkflowEntity.STATUS_REPORTED) {
             notifier.problemReported(
                 mediaTitle = updated.mediaTitle,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/infra/ProblemWorkflowEntity.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/infra/ProblemWorkflowEntity.kt
@@ -18,7 +18,6 @@ data class MediaSnapshot(
     val overview: String? = null,
     val currentQuality: String? = null,
     val currentLanguages: List<String> = emptyList(),
-    // Résolution voulue d'après le profil Radarr (ex : "1080"), sert de référence aux recommandations
     val desiredResolution: String? = null,
 )
 
@@ -31,7 +30,6 @@ data class GrabbedRelease(
     val size: Long? = null,
 )
 
-// Objet racine obligatoire pour le client PG réactif (jamais une List à la racine du JSONB)
 data class ProblemWorkflowState(
     val media: MediaSnapshot? = null,
     val grabbedRelease: GrabbedRelease? = null,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/infra/ProblemWorkflowRepository.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/infra/ProblemWorkflowRepository.kt
@@ -52,7 +52,6 @@ class ProblemWorkflowRepository : ProblemWorkflows {
         is Accessor.Admin -> ProblemWorkflowEntity.find("id = ?1", id).firstResult()
     }
 
-    // Complète les workflows en attente dont le film vient d'être importé après le grab. Idempotent.
     override suspend fun completeAwaitingForMovies(movieIdToImportedAt: Map<Int, LocalDateTime>): Int {
         if (movieIdToImportedAt.isEmpty()) return 0
         return Panache.withTransaction {

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/infra/RadarrProblemsAdapter.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/problems/infra/RadarrProblemsAdapter.kt
@@ -31,8 +31,6 @@ class RadarrProblemsAdapter(
         radarrRestClient.grabRelease(RadarrGrabRequest(guid, indexerId))
     }
 
-    // Résolution cible (cutoff) de chaque profil de qualité. Best-effort : en cas d'échec, on
-    // recommande de façon permissive plutôt que de casser la recherche de films.
     private suspend fun desiredResolutionByProfile(): Map<Int, String> =
         try {
             radarrRestClient.getQualityProfiles().orEmpty()
@@ -47,7 +45,6 @@ class RadarrProblemsAdapter(
             emptyMap()
         }
 
-    // Le cutoff référence soit l'id d'une qualité (feuille), soit l'id d'un groupe de qualités
     private fun RadarrQualityProfile.cutoffResolution(): Int? {
         val target = cutoff ?: return null
         fun find(items: List<RadarrQualityProfileItem>): Int? {

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/arr/bazarr/Models.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/arr/bazarr/Models.kt
@@ -2,7 +2,6 @@ package org.hoohoot.homelab.manager.shared.arr.bazarr
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-// Actions Bazarr considérées comme un téléchargement de sous-titres
 object BazarrActions {
     const val DOWNLOADED = 1
     const val UPGRADED = 3

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/arr/radarr/RadarrRestClient.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/arr/radarr/RadarrRestClient.kt
@@ -59,7 +59,6 @@ interface RadarrRestClient {
     @Path("/tag")
     suspend fun getTags(): List<ArrTag>?
 
-    // Suppression idempotente : un 404 au retry signifie déjà supprimé, le @Retry de classe reste acceptable
     @DELETE
     @Path("/movie/{id}")
     suspend fun deleteMovie(

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/matrix/bot/MatrixBotLifecycle.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/matrix/bot/MatrixBotLifecycle.kt
@@ -117,7 +117,6 @@ class MatrixBotLifecycle(
         val relatesTo = event.content.relatesTo ?: return
         val key = relatesTo.key ?: return
 
-        // Un handler qui échoue ne doit pas empêcher les autres de traiter la réaction
         for (handler in reactionHandlers.all()) {
             try {
                 handler.handle(session, sender, roomId, relatesTo.eventId, key)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/matrix/bot/reactions/ReactionBotHandler.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/matrix/bot/reactions/ReactionBotHandler.kt
@@ -5,7 +5,6 @@ import de.connect2x.trixnity.core.model.RoomId
 import de.connect2x.trixnity.core.model.UserId
 import org.hoohoot.homelab.manager.shared.matrix.bot.MatrixBotSession
 
-// Réagit aux réactions emoji des utilisateurs autorisés (jamais celles du bot lui-même)
 interface ReactionBotHandler {
     suspend fun handle(
         session: MatrixBotSession,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/security/OperatorApiKeyFilter.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/security/OperatorApiKeyFilter.kt
@@ -16,10 +16,6 @@ private const val API_KEY_HEADER = "X-Api-Key"
 @Retention(AnnotationRetention.RUNTIME)
 annotation class OperatorApiKeyProtected
 
-/**
- * Auth simple par clé partagée pour les endpoints appelés par l'opérateur k8s.
- * Le chemin est en policy "permit" côté HTTP : ce filtre est la seule garde, fail-closed si la clé n'est pas configurée.
- */
 @Provider
 @OperatorApiKeyProtected
 class OperatorApiKeyFilter(

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/vertx/VertxCoroutines.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/shared/vertx/VertxCoroutines.kt
@@ -14,11 +14,7 @@ class VertxContextDispatcher(private val context: Context) : CoroutineDispatcher
     }
 }
 
-/**
- * Exécute [block] sur un contexte Vertx duplé et marqué safe — prérequis d'Hibernate Reactive
- * Panache. Nécessaire pour le code appelé hors requête HTTP ou scheduler Quarkus (ex : commandes
- * du bot Matrix qui tournent sur les dispatchers trixnity).
- */
+// Hibernate Reactive Panache exige un contexte Vertx duplé et marqué safe hors requête HTTP/scheduler
 suspend fun <T> runOnSafeVertxContext(vertx: Vertx, block: suspend () -> T): T {
     val context = VertxContext.getOrCreateDuplicatedContext(vertx)
     VertxContextSafetyToggle.setContextSafe(context, true)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/api/AdminStatisticsResource.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/api/AdminStatisticsResource.kt
@@ -36,11 +36,6 @@ class AdminStatisticsResource(
     private val vertx: Vertx,
 ) {
 
-    /**
-     * Stage le fichier de backup uploadé et déclenche l'import en arrière-plan (202) :
-     * le fichier fait des centaines de Mo, l'import est trop long pour la requête.
-     * Suivi via l'API admin jobs (identité "jellystat-import").
-     */
     @POST
     @Path("/import")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -59,8 +54,6 @@ class AdminStatisticsResource(
         return Response.accepted(ImportStartedDto(JellystatImportJob.IDENTITY)).build()
     }
 
-    // L'import survit à la requête : coroutine sur un contexte Vertx duplé et marqué safe,
-    // condition pour que Hibernate Reactive accepte d'y ouvrir des sessions
     private fun launchInBackground(block: suspend () -> Unit) {
         val context = VertxContext.getOrCreateDuplicatedContext(vertx)
         VertxContextSafetyToggle.setContextSafe(context, true)

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/PeriodResolver.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/PeriodResolver.kt
@@ -10,10 +10,6 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.TemporalAdjusters
 
-/**
- * Bornes d'une période de stats : `[fromUtc, toUtc)` pour filtrer la base (stockée en UTC),
- * `[fromLocal, toLocal)` en heure locale d'affichage pour combler les buckets vides des graphes.
- */
 data class StatsRange(
     val fromUtc: LocalDateTime,
     val toUtc: LocalDateTime,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/ports/PlaybackSessions.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/ports/PlaybackSessions.kt
@@ -5,6 +5,5 @@ import org.hoohoot.homelab.manager.statistics.domain.PlaybackSessionRecord
 interface PlaybackSessions {
     suspend fun saveAll(records: List<PlaybackSessionRecord>)
 
-    /** Insère en ignorant les doublons (dédup sur import_key) et retourne le nombre de lignes réellement insérées. */
     suspend fun insertIgnoringDuplicates(records: List<PlaybackSessionRecord>): Int
 }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/ports/StatisticsQueries.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/ports/StatisticsQueries.kt
@@ -28,7 +28,6 @@ interface StatisticsQueries {
     suspend fun platformBreakdown(range: StatsRange): List<PlatformShare>
     suspend fun playsOverTime(range: StatsRange, granularity: TimeGranularity): List<TimePoint>
 
-    // Requêtes du bot Matrix / weekly report (bornes UTC brutes, pas de notion de période d'affichage)
     suspend fun mostPopular(fromUtc: LocalDateTime, toUtc: LocalDateTime, kind: MediaKind, limit: Int): List<MostPopular>
     suspend fun mostViewed(fromUtc: LocalDateTime, toUtc: LocalDateTime, kind: MediaKind, limit: Int): List<MostViewed>
     suspend fun seriesWatchers(seriesId: String): List<SeriesWatcher>

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/usecases/GetPlaysOverTime.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/usecases/GetPlaysOverTime.kt
@@ -33,7 +33,6 @@ class GetPlaysOverTime(
         granularity: TimeGranularity,
         allTime: Boolean,
     ): List<TimePoint> {
-        // All time : combler depuis le premier point mesuré, pas depuis epoch
         val start = if (allTime) points.firstOrNull()?.bucketStart ?: return emptyList() else fromLocal
         val byBucket = points.associateBy { it.bucketStart }
         val filled = mutableListOf<TimePoint>()

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/usecases/GetTopMedia.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/usecases/GetTopMedia.kt
@@ -30,7 +30,6 @@ class GetTopMedia(
         limit: Int = 10,
     ): List<TopMediaItem> {
         val range = periodResolver.resolve(period)
-        // Le binge score n'existe pas pour les films : retomber sur le tri par défaut
         val effectiveSort = if (kind == MediaKind.MOVIE && sort == TopMediaSort.BINGE_SCORE) TopMediaSort.PLAYS else sort
         return when (kind) {
             MediaKind.SERIES -> queries.topSeries(range, limit, effectiveSort, direction).map {

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/usecases/ImportJellystatBackup.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/domain/usecases/ImportJellystatBackup.kt
@@ -16,8 +16,6 @@ class ImportJellystatBackup(
     private val playbackSessions: PlaybackSessions,
 ) {
     suspend operator fun invoke(file: Path): ImportResult {
-        // Lecture bloquante d'un gros fichier : déportée sur un worker Vertx (pas Dispatchers.IO,
-        // dont les threads n'ont pas le classloader Quarkus)
         val content = VertxContextSupport.executeBlocking(Callable { reader.read(file) }).awaitSuspending()
         var imported = 0
         content.records.chunked(BATCH_SIZE).forEach { batch ->

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/infra/StatisticsRepository.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/infra/StatisticsRepository.kt
@@ -24,10 +24,6 @@ import org.hoohoot.homelab.manager.statistics.domain.WeekdayActivity
 import org.hoohoot.homelab.manager.statistics.domain.ports.StatisticsQueries
 import java.time.LocalDateTime
 
-/**
- * Agrégations SQL natives sur playback_session. La base stocke des timestamps UTC ;
- * les regroupements heure/jour utilisent le double AT TIME ZONE pour raisonner en heure locale.
- */
 @ApplicationScoped
 class StatisticsRepository(
     @param:ConfigProperty(name = "statistics.timezone") private val timezone: String,
@@ -304,7 +300,6 @@ class StatisticsRepository(
     }
 
     companion object {
-        /** Binge score = min(100, moyenne d'épisodes distincts vus par jour actif et par user ÷ cap × 100). */
         private const val BINGE_CAP_EPISODES_PER_DAY = 6.0
     }
 }

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/infra/imports/JellystatBackupParser.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/infra/imports/JellystatBackupParser.kt
@@ -16,18 +16,6 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 
-/**
- * Parse un fichier de backup Jellystat : tableau racine d'objets à clé unique, une par table
- * (`jf_library_items`, `jf_library_episodes`, `jf_playback_activity`, ...).
- *
- * Le fichier peut peser des centaines de Mo (l'essentiel vient des MediaStreams de chaque session) :
- * parsing en streaming Jackson, ligne à ligne, sans jamais matérialiser l'arbre complet.
- * Deux passes pour ne pas dépendre de l'ordre des tables : la première construit les lookups
- * épisodes/items (runtime, saison/épisode, nom de série propre), la seconde mappe les sessions.
- *
- * La progression/complétion est estimée par `durée visionnée / runtime` (suppose un visionnage
- * linéaire, sans skip) — le backup ne contient pas la position de lecture finale.
- */
 @ApplicationScoped
 class JellystatBackupParser(
     private val objectMapper: ObjectMapper,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/infra/imports/JellystatImportJob.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/infra/imports/JellystatImportJob.kt
@@ -10,13 +10,6 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.concurrent.atomic.AtomicBoolean
 
-/**
- * Import du backup Jellystat, découplé de l'upload HTTP : l'endpoint admin stage le fichier
- * puis déclenche ce job en arrière-plan (le fichier fait des centaines de Mo, le parsing et
- * les insertions dépassent le budget d'une requête). Pas de @Scheduled : déclenchement
- * uniquement via runNow — relançable depuis l'UI admin jobs tant que le fichier stagé existe
- * (il n'est supprimé qu'en fin d'import réussi).
- */
 @ApplicationScoped
 class JellystatImportJob(
     private val importJellystatBackup: ImportJellystatBackup,

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/infra/polling/JellyfinSessionPoller.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/infra/polling/JellyfinSessionPoller.kt
@@ -15,12 +15,6 @@ import org.hoohoot.homelab.manager.statistics.domain.ports.PlaybackSessions
 import java.time.Duration
 import java.time.Instant
 
-/**
- * Polle GET /Sessions de Jellyfin à intervalle court pour alimenter l'historique de visionnage.
- *
- * Volontairement hors du pattern ManagedJob/JobRunner : un tick toutes les 15 s inonderait
- * la table job_execution. Les erreurs (Jellyfin injoignable) sont loguées en warn throttlé.
- */
 @ApplicationScoped
 class JellyfinSessionPoller(
     @param:RestClient private val jellyfin: JellyfinRestClient,
@@ -67,7 +61,6 @@ class JellyfinSessionPoller(
             val mediaType = when (item.type) {
                 "Movie" -> MediaType.MOVIE
                 "Episode" -> MediaType.EPISODE
-                // Trailers, audio, live TV, livres... hors périmètre des stats
                 else -> return null
             }
             return ActiveSession(

--- a/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/infra/polling/SessionTracker.kt
+++ b/app/src/main/kotlin/org/hoohoot/homelab/manager/statistics/infra/polling/SessionTracker.kt
@@ -38,16 +38,6 @@ private class TrackedSession(
     var last: ActiveSession,
 )
 
-/**
- * Suit les sessions de lecture Jellyfin entre deux snapshots de GET /Sessions et produit
- * les sessions terminées (disparues du snapshot ou périmées) prêtes à persister.
- *
- * L'état vit en mémoire : il est perdu au redémarrage (les sessions en cours à ce moment-là
- * ne sont pas comptabilisées, compromis accepté) et suppose une instance unique de l'application.
- *
- * Le temps de pause est accumulé par delta entre deux ticks où la session est en pause ; la durée
- * réellement visionnée est donc `(dernière vue − début) − pauses`, à la granularité du polling près.
- */
 class SessionTracker(
     private val minPlaySeconds: Long,
     private val staleAfterSeconds: Long,
@@ -65,8 +55,6 @@ class SessionTracker(
             val tracked = sessions[key]
             when {
                 tracked == null -> sessions[key] = TrackedSession(now, now, 0, session)
-                // Trou de polling trop long (Jellyfin injoignable) : on clôt l'ancienne session
-                // plutôt que de lui imputer tout le temps du trou, et on en démarre une nouvelle
                 isStale(tracked, now) -> {
                     finalize(tracked)?.let(finished::add)
                     sessions[key] = TrackedSession(now, now, 0, session)

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/cleanup/CandidateScorerTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/cleanup/CandidateScorerTest.kt
@@ -150,7 +150,6 @@ internal class CandidateScorerTest {
         val breakdown = scorer.evaluate(input()).breakdown()
 
         assertThat(breakdown.component("requesterActivity").points).isEqualTo(0.0)
-        // 82.5 points sur 90 de poids -> 91.67 une fois renormalisé
         assertThat(breakdown.total).isEqualTo(91.67)
     }
 

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/ApplicationsTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/ApplicationsTest.kt
@@ -314,7 +314,6 @@ internal class ApplicationsTest {
             .then().statusCode(Response.Status.CREATED.statusCode)
             .extract().jsonPath().getString("id")
 
-        // Simule une édition depuis l'admin UI, qui n'envoie pas les champs managed
         RestAssured.given()
             .multiPart("name", "Radarr Films")
             .multiPart(utf8Part("category", "Médias"))

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/BotCommandsTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/BotCommandsTest.kt
@@ -137,8 +137,6 @@ internal class BotCommandsTest {
 
     @Test
     fun `top-watchers should return top watchers list`() {
-        // Grosses durées : alice et bob doivent rester dans le top 10 all-time malgré
-        // les sessions seedées par les autres classes de test (base partagée)
         PlaybackSessionSeed.insertSession(userName = "alice", userId = "bot-alice", itemName = "Marathon Movie", mediaType = MediaType.MOVIE, durationSeconds = 180000)
         PlaybackSessionSeed.insertSession(userName = "bob", userId = "bot-bob", itemName = "Marathon Movie", mediaType = MediaType.MOVIE, durationSeconds = 90000)
 
@@ -194,11 +192,8 @@ internal class BotCommandsTest {
 
         val response = synapseTestClient.waitForBotMessage(roomId)
         val body = response.get("body").asText()
-        // The response is a random deado variant, just check it's not empty
         assertThat(body).isNotBlank()
     }
-
-    // WireMock stub helpers
 
     private fun stubJellyfinSearch() {
         wireMock.register(

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/CleanupSuggestionsTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/CleanupSuggestionsTest.kt
@@ -49,7 +49,6 @@ internal class CleanupSuggestionsTest {
 
     private lateinit var mediaRoomId: String
 
-    // Série terminée à deux saisons (30 + 20 Go) : suggestible saison par saison ou en entier
     private val wireSeriesJson = """
         {
           "id": 201, "title": "The Wire", "year": 2002, "tvdbId": 79126, "ended": true,
@@ -82,7 +81,6 @@ internal class CleanupSuggestionsTest {
         wireMock.resetRequests()
         registerDefaultStubs()
 
-        // Chaque test poste dans une room fraîche : les assertions sur les messages restent isolées
         mediaRoomId = synapseTestClient.createRoom("media-${System.nanoTime()}")
         roomProvider.media = mediaRoomId
     }
@@ -177,7 +175,6 @@ internal class CleanupSuggestionsTest {
             .contains("Inception")
             .contains("❌")
 
-        // L'event id de l'annonce est persisté : c'est lui que l'exécution interrogera pour les vetos
         val stored = CleanupSeed.suggestion(UUID.fromString(suggestion.getString("id")))
         assertThat(stored?.announcementEventId).isEqualTo(announcement.get("event_id").asText())
 
@@ -215,7 +212,6 @@ internal class CleanupSuggestionsTest {
     fun `sans veto le film est supprimé via radarr à l'échéance et l'issue est annoncée`() {
         val suggestionId = UUID.fromString(suggest("MOVIE", radarrMovieId = 101).getString("id"))
 
-        // Une réaction qui n'est pas ❌ est un simple vote, pas un veto
         val announcementEventId = synapseTestClient.getLastMessageEvent(mediaRoomId).get("event_id").asText()
         synapseTestClient.sendReaction(mediaRoomId, announcementEventId, "👍")
 
@@ -236,7 +232,6 @@ internal class CleanupSuggestionsTest {
             .contains("Suppression effectuée")
             .contains("Inception")
 
-        // L'issue reste visible quelques jours dans l'UI
         val recent = listSuggestions()
         assertThat(recent).hasSize(1)
         assertThat(recent.first()["status"]).isEqualTo("DELETED")
@@ -267,7 +262,6 @@ internal class CleanupSuggestionsTest {
     @Test
     @TestSecurity(user = "bob", roles = ["user"])
     fun `une réaction ❌ est acquittée immédiatement sans attendre l'échéance`() {
-        // Le bot est dans la room : son sync voit la réaction arriver en direct
         synapseTestClient.inviteUser(mediaRoomId, "@johnnybot:localhost")
 
         val suggestionId = UUID.fromString(suggest("MOVIE", radarrMovieId = 101).getString("id"))
@@ -283,7 +277,6 @@ internal class CleanupSuggestionsTest {
         val vetoed = CleanupSeed.suggestion(suggestionId)
         assertThat(vetoed?.vetoedBy).isEqualTo("admin")
 
-        // L'issue est annoncée dans le chat sans attendre le job d'échéance
         await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(500)).untilAsserted {
             assertThat(synapseTestClient.getLastMessage(mediaRoomId).get("body").asText())
                 .contains("Veto")
@@ -291,7 +284,6 @@ internal class CleanupSuggestionsTest {
         }
         wireMock.verifyThat(0, deleteRequestedFor(urlPathMatching("/api/v3/movie/\\d+")))
 
-        // Et l'UI reflète le veto
         val recent = listSuggestions()
         assertThat(recent).hasSize(1)
         assertThat(recent.first()["status"]).isEqualTo("VETOED")
@@ -315,7 +307,6 @@ internal class CleanupSuggestionsTest {
         )
         val deleted = CleanupSeed.suggestion(suggestionId)
         assertThat(deleted?.status).isEqualTo(CleanupSuggestionEntity.STATUS_DELETED)
-        // Les octets libérés sont mesurés sur les fichiers d'épisodes au moment de la suppression
         assertThat(deleted?.freedBytes).isEqualTo(50 * GB)
     }
 
@@ -330,7 +321,6 @@ internal class CleanupSuggestionsTest {
         CleanupSeed.makeSuggestionDue(suggestionId)
         runJob("cleanup-suggestions")
 
-        // La saison est dé-monitorée puis ses fichiers supprimés un à un : la série reste en place
         wireMock.verifyThat(
             putRequestedFor(urlPathEqualTo("/api/v3/series/201"))
                 .withRequestBody(matchingJsonPath("$.seasons[0].monitored", equalTo("false")))
@@ -359,7 +349,6 @@ internal class CleanupSuggestionsTest {
             .`when`().post("/api/cleanup/suggestions")
             .then().statusCode(Response.Status.CONFLICT.statusCode)
 
-        // La saison protégée est intouchable, mais l'autre saison reste suggérable
         suggest("SEASON", sonarrSeriesId = 201, seasonNumber = 1)
         RestAssured.given()
             .contentType(ContentType.JSON)
@@ -373,7 +362,6 @@ internal class CleanupSuggestionsTest {
     fun `une suggestion de saison et une suggestion de la même série entière s'excluent mutuellement`() {
         suggest("SEASON", sonarrSeriesId = 201, seasonNumber = 1)
 
-        // La série entière emporterait la saison déjà en attente de veto
         RestAssured.given()
             .contentType(ContentType.JSON)
             .body(mapOf("mediaKind" to "SERIES", "sonarrSeriesId" to 201))
@@ -383,7 +371,6 @@ internal class CleanupSuggestionsTest {
         CleanupSeed.deleteAll()
         suggest("SERIES", sonarrSeriesId = 201)
 
-        // Inversement, une saison couverte par une série en attente ne peut pas être re-suggérée
         RestAssured.given()
             .contentType(ContentType.JSON)
             .body(mapOf("mediaKind" to "SEASON", "sonarrSeriesId" to 201, "seasonNumber" to 2))

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/CleanupTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/CleanupTest.kt
@@ -47,7 +47,6 @@ internal class CleanupTest {
     @Inject
     lateinit var wireMock: WireMock
 
-    // Série terminée dont la saison 1 (30 Go, jamais visionnée) est candidate au nettoyage
     private val wireSeriesJson = """
         {
           "id": 201, "title": "The Wire", "year": 2002, "tvdbId": 79126, "ended": true,
@@ -104,7 +103,6 @@ internal class CleanupTest {
                 )
             )
         )
-        // Un seul WireMock : ce stub sert les tags Radarr et Sonarr
         wireMock.register(
             get(urlPathEqualTo("/api/v3/tag")).willReturn(okJson("""[{"id": 1, "label": "1 - john"}]"""))
         )
@@ -203,7 +201,6 @@ internal class CleanupTest {
     @Test
     @TestSecurity(user = "alice", roles = ["admin", "user"])
     fun `le job cleanup-scan démarre une campagne avec les candidats triés par score décroissant`() {
-        // « Le Voyage » a été vu en entier récemment : il doit scorer moins qu'« Inception » jamais visionné
         PlaybackSessionSeed.insertSession(
             userName = "cleanup-watcher",
             itemId = "jf-voyage",
@@ -231,7 +228,6 @@ internal class CleanupTest {
         val recentlyCompleted = (byTitle["Le Voyage"]!!["score"] as Number).toDouble()
         assertThat(neverWatched).isGreaterThan(recentlyCompleted)
 
-        // Le breakdown persisté est explicable : composantes présentes et total cohérent
         assertThat(overview.getList<Any>("campaign.candidates[0].scoreBreakdown.components")).isNotEmpty()
         assertThat(overview.getDouble("campaign.candidates[0].scoreBreakdown.total")).isGreaterThan(0.0)
 
@@ -338,7 +334,6 @@ internal class CleanupTest {
                 .withQueryParam("deleteFiles", equalTo("true"))
                 .withQueryParam("addImportExclusion", equalTo("false"))
         )
-        // La saison est d'abord dé-monitorée puis ses fichiers d'épisodes supprimés un à un
         wireMock.verifyThat(
             putRequestedFor(urlPathEqualTo("/api/v3/series/201"))
                 .withRequestBody(matchingJsonPath("$.seasons[0].monitored", equalTo("false")))
@@ -394,7 +389,6 @@ internal class CleanupTest {
         assertThat(byTitle["Inception"]!!["failureReason"].toString()).isNotBlank()
         assertThat(byTitle["Le Voyage"]!!["status"]).isEqualTo("DELETED")
 
-        // Radarr est réparé : le retry admin rejoue la suppression et crédite la campagne
         wireMock.register(delete(urlPathEqualTo("/api/v3/movie/101")).willReturn(aResponse().withStatus(200)))
 
         val retried = RestAssured.given()
@@ -413,7 +407,6 @@ internal class CleanupTest {
         val campaignId = CleanupSeed.insertCampaign(graceEndsAt = LocalDateTime.now().minusHours(1))
         CleanupSeed.insertCandidate(campaignId, "Inception", radarrMovieId = 101, score = 90.0)
         CleanupSeed.insertCandidate(campaignId, "Le Voyage", radarrMovieId = 102, score = 60.0)
-        // Re-check en direct : 400 Go libres, au-dessus de la cible (50 Go au départ + 250 Go à libérer)
         wireMock.register(
             get(urlPathEqualTo("/api/v3/diskspace")).willReturn(
                 okJson("""[{"path": "/data", "label": "data", "freeSpace": 400000000000, "totalSpace": 1000000000000}]""")
@@ -447,7 +440,6 @@ internal class CleanupTest {
         assertThat(cancelled.getList<Map<String, Any>>("candidates").map { it["status"] })
             .containsOnly("CANCELLED")
 
-        // Plus de campagne active côté user
         assertThat(getOverview().getString("campaign")).isNull()
     }
 

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/EnergyExpenseTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/EnergyExpenseTest.kt
@@ -78,7 +78,6 @@ internal class EnergyExpenseTest {
         assertThat(runJob()).isEqualTo("SUCCESS")
 
         val entries = energyEntries()
-        // Rattrapage : 3 mois en arrière
         assertThat(entries).hasSize(3)
         assertThat(entries).allSatisfy { assertThat(it["type"]).isEqualTo("EXPENSE") }
         assertThat(entries.map { it["period"] }).doesNotHaveDuplicates()
@@ -98,7 +97,6 @@ internal class EnergyExpenseTest {
         assertThat(lastMonthEntry["amountCents"]).isEqualTo(expectedCents)
         assertThat(lastMonthEntry["label"]).isEqualTo("Électricité $previousMonth")
 
-        // Deuxième run : rien de nouveau
         assertThat(runJob()).isEqualTo("SUCCESS")
         assertThat(energyEntries()).hasSize(3)
     }

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/FinanceRecurringJobTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/FinanceRecurringJobTest.kt
@@ -39,7 +39,6 @@ internal class FinanceRecurringJobTest {
 
     private fun entriesWithLabel(label: String): List<Map<String, Any>> {
         val today = LocalDate.now()
-        // Le rattrapage peut chevaucher deux années civiles
         return listOf(today.year, today.year - 1).flatMap { year ->
             RestAssured.given()
                 .`when`().get("/api/finances/entries?year=$year&pageSize=100")
@@ -57,7 +56,6 @@ internal class FinanceRecurringJobTest {
         assertThat(runJob()).isEqualTo("SUCCESS")
 
         val entries = entriesWithLabel("Abonnement box récurrent")
-        // day_of_month=1 : une occurrence pour chacun des 4 mois écoulés (M-3 .. mois courant)
         assertThat(entries).hasSize(4)
         assertThat(entries).allSatisfy {
             assertThat(it["source"]).isEqualTo("RECURRING")
@@ -65,7 +63,6 @@ internal class FinanceRecurringJobTest {
         }
         assertThat(entries.map { it["period"] }).doesNotHaveDuplicates()
 
-        // Deuxième run : aucune écriture supplémentaire
         assertThat(runJob()).isEqualTo("SUCCESS")
         assertThat(entriesWithLabel("Abonnement box récurrent")).hasSize(4)
     }
@@ -80,7 +77,6 @@ internal class FinanceRecurringJobTest {
         assertThat(runJob()).isEqualTo("SUCCESS")
 
         assertThat(entriesWithLabel("Règle inactive")).isEmpty()
-        // end_date = M-2 : seules les occurrences de M-3 et M-2 sont dues
         assertThat(entriesWithLabel("Règle terminée")).hasSize(2)
     }
 }

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/FinancesTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/FinancesTest.kt
@@ -17,8 +17,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
-// Année dédiée à ce test : les totaux ne sont pas pollués par les écritures
-// créées par les autres classes de test (base partagée)
 private const val YEAR = 2031
 
 @QuarkusTest

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/JobsAdminTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/JobsAdminTest.kt
@@ -89,7 +89,6 @@ internal class JobsAdminTest {
             .`when`().post("/api/admin/jobs/sonarr-sync/run")
             .then().statusCode(Response.Status.OK.statusCode)
 
-        // Different live values from now on: /api/stats must keep serving the persisted snapshot
         wireMock.register(
             get(urlPathEqualTo("/api/v3/movie")).willReturn(okJson("""[{"id": 9, "title": "Alien"}]"""))
         )
@@ -102,7 +101,6 @@ internal class JobsAdminTest {
         assertThat(stats.getInt("movieCount")).isEqualTo(2)
         assertThat(stats.getInt("seriesCount")).isEqualTo(1)
         assertThat(stats.getInt("episodeCount")).isEqualTo(28)
-        // Radarr and Sonarr snapshots both report /data: the merge dedupes it
         assertThat(stats.getLong("diskTotalBytes")).isEqualTo(2000)
         assertThat(stats.getLong("diskFreeBytes")).isEqualTo(500)
         assertThat(stats.getLong("diskUsedBytes")).isEqualTo(1500)

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/MemberSyncTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/MemberSyncTest.kt
@@ -66,14 +66,11 @@ internal class MemberSyncTest {
         assertThat(paul["displayName"]).isEqualTo("Paul Sync")
         assertThat(paul["email"]).isEqualTo("paul@hoohoot.org")
         assertThat(paul["fromAuthentik"]).isEqualTo(true)
-        // name vide → fallback sur le username
         assertThat(members.first { it["username"] == "sync-noah" }["displayName"]).isEqualTo("sync-noah")
 
-        // Re-run à l'identique : idempotent, pas de doublon
         assertThat(runSync()).isEqualTo("SUCCESS")
         assertThat(fetchMembers().filter { (it["username"] as String).startsWith("sync-") }).hasSize(3)
 
-        // Mara disparaît de l'annuaire : désactivée mais conservée (historique des cotisations)
         wireMock.resetMappings()
         stubUsersPage(
             page = 1, next = 0,

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/ProblemsNotificationsTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/ProblemsNotificationsTest.kt
@@ -39,7 +39,6 @@ internal class ProblemsNotificationsTest {
         wireMock.resetMappings()
         wireMock.resetRequests()
 
-        // Stub Radarr movies
         wireMock.register(
             get(urlPathEqualTo("/api/v3/movie")).willReturn(
                 okJson(
@@ -59,7 +58,6 @@ internal class ProblemsNotificationsTest {
             )
         )
 
-        // Stub quality profiles
         wireMock.register(
             get(urlPathEqualTo("/api/v3/qualityprofile")).willReturn(
                 okJson(
@@ -76,12 +74,10 @@ internal class ProblemsNotificationsTest {
             )
         )
 
-        // Stub release grab
         wireMock.register(
             post(urlPathEqualTo("/api/v3/release")).willReturn(okJson("""{"guid": "release-1", "indexerId": 1}"""))
         )
 
-        // Stub Sonarr series
         wireMock.register(
             get(urlPathEqualTo("/api/v3/series")).willReturn(
                 okJson(
@@ -133,7 +129,6 @@ internal class ProblemsNotificationsTest {
     fun `le signalement d'un probleme envoie une notification en thread du message de creation`() {
         val id = createWorkflow()
 
-        // Récupère l'event_id du message de création (racine du thread)
         val createEventId = synapseTestClient.getLastMessageEvent(supportRoomId).get("event_id").asText()
 
         selectMovie(id)
@@ -144,7 +139,6 @@ internal class ProblemsNotificationsTest {
         assertThat(lastMessage.get("body").asText()).contains("@alice")
         assertThat(lastMessage.get("body").asText()).contains("Le fichier est corrompu")
 
-        // Vérifie que le message est en thread du message de création
         val lastEvent = synapseTestClient.getLastMessageEvent(supportRoomId)
         val relatesTo = lastEvent.get("content").get("m.relates_to")
         assertThat(relatesTo).isNotNull()
@@ -161,18 +155,15 @@ internal class ProblemsNotificationsTest {
 
         resolveWorkflow(id)
 
-        // Vérifie le message de résolution
         val lastMessage = synapseTestClient.getLastMessage(supportRoomId)
         assertThat(lastMessage.get("body").asText()).contains("🙄 Problème résolu")
         assertThat(lastMessage.get("body").asText()).contains("@alice")
         assertThat(lastMessage.get("body").asText()).contains("fallait juste chercher un peu")
 
-        // Vérifie que le message est en thread
         val lastEvent = synapseTestClient.getLastMessageEvent(supportRoomId)
         val resolutionRelatesTo = lastEvent.get("content").get("m.relates_to")
         assertThat(resolutionRelatesTo.get("rel_type").asText()).isEqualTo("m.thread")
 
-        // Vérifie la réaction ✅ sur le message racine du thread
         val reactions = synapseTestClient.getReactions(supportRoomId)
         assertThat(reactions).isNotEmpty()
 
@@ -189,7 +180,6 @@ internal class ProblemsNotificationsTest {
         selectMovie(id)
         selectProblem(id, problemType = "other", description = "Problème test")
 
-        // Résolution par admin via l'endpoint admin
         RestAssured.given()
             .`when`().post("/api/admin/problems/workflows/$id/resolve")
             .then().statusCode(Response.Status.OK.statusCode)

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/ProblemsTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/ProblemsTest.kt
@@ -111,7 +111,6 @@ internal class ProblemsTest {
                 )
             )
         )
-        // Oppenheimer n'a pas de fichier : la contrainte de résolution est levée
         wireMock.register(
             get(urlPathEqualTo("/api/v3/release")).withQueryParam("movieId", equalTo("2")).willReturn(
                 okJson(
@@ -130,7 +129,6 @@ internal class ProblemsTest {
         wireMock.register(
             post(urlPathEqualTo("/api/v3/release")).willReturn(okJson("""{"guid": "release-multi", "indexerId": 1}"""))
         )
-        // Profil « HD-1080p » : cutoff = groupe « WEB 1080p » (cas réel du profil Radarr par défaut)
         wireMock.register(
             get(urlPathEqualTo("/api/v3/qualityprofile")).willReturn(
                 okJson(
@@ -155,7 +153,6 @@ internal class ProblemsTest {
                 )
             )
         )
-        // Blade Runner 2049 : releases FR pour le film au profil 4K (movieId 5)
         wireMock.register(
             get(urlPathEqualTo("/api/v3/release")).withQueryParam("movieId", equalTo("5")).willReturn(
                 okJson(
@@ -363,7 +360,6 @@ internal class ProblemsTest {
         assertThat(workflow.getString("media.posterUrl")).isEqualTo("https://img/dune2.jpg")
         assertThat(workflow.getString("media.currentQuality")).isEqualTo("Bluray-720p")
         assertThat(workflow.getList<String>("media.currentLanguages")).containsExactly("English")
-        // Résolution voulue issue du profil Radarr (cutoff), pas celle du fichier 720p actuel
         assertThat(workflow.getString("media.desiredResolution")).isEqualTo("1080")
     }
 
@@ -518,13 +514,11 @@ internal class ProblemsTest {
 
         assertThat(releases).hasSize(5)
         val byGuid = releases.associateBy { it["guid"] }
-        // MULTI dans le titre = FR, même si Radarr ne parse pas de langue French
         assertThat(byGuid["release-multi"]!!["isFrench"]).isEqualTo(true)
         assertThat(byGuid["release-truefrench"]!!["isFrench"]).isEqualTo(true)
         assertThat(byGuid["release-french-language"]!!["isFrench"]).isEqualTo(true)
         assertThat(byGuid["release-vostfr"]!!["isFrench"]).isEqualTo(false)
         assertThat(byGuid["release-vo"]!!["isFrench"]).isEqualTo(false)
-        // Tri : françaises d'abord, puis par seeders
         assertThat(releases.map { it["guid"] })
             .containsExactly("release-multi", "release-truefrench", "release-french-language", "release-vo", "release-vostfr")
     }
@@ -566,7 +560,6 @@ internal class ProblemsTest {
     @TestSecurity(user = "alice", roles = ["admin", "user"])
     fun `radarr sync ignores imports that happened before the grab`() {
         val id = runToAwaitingImport()
-        // L'import VO d'origine réapparaît dans l'historique à cause de l'overlap du watermark
         registerRadarrImportHistory(movieId = 1, importedAt = Instant.now().minus(2, ChronoUnit.HOURS))
 
         runJob("radarr-downloads-sync")
@@ -643,17 +636,12 @@ internal class ProblemsTest {
             .extract().jsonPath().getList<Map<String, Any>>("")
 
         val byGuid = releases.associateBy { it["guid"] }
-        // Le fichier actuel est en 720p mais le profil demande du 1080p : on recommande l'upgrade
-        // MULTI 1080p, même s'il est rejeté par les règles Radarr (taille/format).
         assertThat(byGuid["release-multi"]!!["isRecommended"]).isEqualTo(true)
         assertThat(byGuid["release-multi"]!!["rejected"]).isEqualTo(true)
-        // 720p alors que la qualité demandée est 1080p
         assertThat(byGuid["release-truefrench"]!!["isRecommended"]).isEqualTo(false)
-        // usenet, et pas de tag VF dans le titre
         assertThat(byGuid["release-french-language"]!!["isRecommended"]).isEqualTo(false)
         assertThat(byGuid["release-vo"]!!["isRecommended"]).isEqualTo(false)
         assertThat(byGuid["release-vostfr"]!!["isRecommended"]).isEqualTo(false)
-        // Tri : recommandées d'abord
         assertThat(releases.first()["guid"]).isEqualTo("release-multi")
     }
 
@@ -670,7 +658,6 @@ internal class ProblemsTest {
             .extract().jsonPath().getList<Map<String, Any>>("")
 
         val byGuid = releases.associateBy { it["guid"] }
-        // Profil 1080p : on recommande la 1080p MULTI, pas la 2160p (qualité au-dessus de la demandée)
         assertThat(byGuid["br-multi-1080"]!!["isRecommended"]).isEqualTo(true)
         assertThat(byGuid["br-multi-2160"]!!["isRecommended"]).isEqualTo(false)
     }
@@ -678,7 +665,6 @@ internal class ProblemsTest {
     @Test
     @TestSecurity(user = "alice", roles = ["admin", "user"])
     fun `the resolution constraint is lifted when the desired resolution is unknown`() {
-        // Oppenheimer n'a pas de qualityProfileId : on ne connaît pas la résolution voulue → permissif
         val id = createWorkflow().getString("id")
         selectMovie(id, radarrMovieId = 2)
         selectProblem(id)
@@ -719,12 +705,10 @@ internal class ProblemsTest {
     fun `an admin can take over another user's workflow without reassigning it`() {
         val bobWorkflowId = insertWorkflowFor("bob")
 
-        // Le endpoint user ne voit pas le workflow de bob
         RestAssured.given().contentType(ContentType.JSON).body("""{"radarrMovieId": 1}""")
             .`when`().post("/api/problems/workflows/$bobWorkflowId/movie")
             .then().statusCode(Response.Status.NOT_FOUND.statusCode)
 
-        // Le endpoint admin déroule les mêmes étapes
         val afterMovie = RestAssured.given().contentType(ContentType.JSON).body("""{"radarrMovieId": 1}""")
             .`when`().post("/api/admin/problems/workflows/$bobWorkflowId/movie")
             .then().statusCode(Response.Status.OK.statusCode)
@@ -735,7 +719,6 @@ internal class ProblemsTest {
             .`when`().post("/api/admin/problems/workflows/$bobWorkflowId/problem")
             .then().statusCode(Response.Status.OK.statusCode)
 
-        // Le workflow reste celui de bob
         val adminView = RestAssured.given()
             .`when`().get("/api/admin/problems/workflows/$bobWorkflowId")
             .then().statusCode(Response.Status.OK.statusCode)

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/StatisticsApiTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/StatisticsApiTest.kt
@@ -12,21 +12,12 @@ import org.junit.jupiter.api.Test
 import java.io.File
 import java.time.LocalDateTime
 
-/**
- * Dataset volontairement daté en juin 2020 (aucune autre classe de test ne seede cette période)
- * et purgé à chaque test : les assertions en ALL_TIME sont exactes.
- *
- * marie : 6 épisodes de "Stats Show" (3 par jour sur 2 jours, complétés, 30 min chacun, à 14h Paris)
- *         + le film "Stats Movie" complété (2 h, 20h Paris).
- * jean : le même film, non complété (1 h, 21h Paris).
- */
 @QuarkusTest
 internal class StatisticsApiTest {
 
     @BeforeEach
     fun setUp() {
         PlaybackSessionSeed.deleteAll()
-        // 2020-06-10 (mercredi) et 2020-06-11 (jeudi) : 3 épisodes par jour à 12h UTC = 14h Paris (été)
         listOf("2020-06-10", "2020-06-11").forEachIndexed { day, date ->
             repeat(3) { index ->
                 val episode = day * 3 + index + 1
@@ -46,7 +37,6 @@ internal class StatisticsApiTest {
                 )
             }
         }
-        // 2020-06-12 (vendredi) : le film, vu par marie (complété) et jean (non complété)
         PlaybackSessionSeed.insertSession(
             userName = "stats-marie",
             itemId = "stats-movie",
@@ -112,7 +102,6 @@ internal class StatisticsApiTest {
         assertThat(series.getLong("[0].watchTimeSeconds")).isEqualTo(10800L)
         assertThat(series.getLong("[0].uniqueViewers")).isEqualTo(1L)
         assertThat(series.getDouble("[0].completionRate")).isEqualTo(100.0)
-        // 3 épisodes par jour actif en moyenne, cap à 6 par jour => score 50
         assertThat(series.getInt("[0].bingeScore")).isEqualTo(50)
     }
 
@@ -128,7 +117,6 @@ internal class StatisticsApiTest {
         assertThat(movies.getLong("[0].plays")).isEqualTo(2L)
         assertThat(movies.getLong("[0].watchTimeSeconds")).isEqualTo(10800L)
         assertThat(movies.getLong("[0].uniqueViewers")).isEqualTo(2L)
-        // marie a complété, jean non => 50 % des visionneurs
         assertThat(movies.getDouble("[0].completionRate")).isEqualTo(50.0)
         assertThat(movies.getString("[0].bingeScore")).isNull()
     }
@@ -136,7 +124,6 @@ internal class StatisticsApiTest {
     @Test
     @TestSecurity(user = "bob", roles = ["user"])
     fun `top media is sorted by plays by default and honors the sort parameters`() {
-        // Second film : moins de visionnages mais 100 % de complétion
         PlaybackSessionSeed.insertSession(
             userName = "stats-luc",
             itemId = "stats-movie-b",
@@ -171,10 +158,10 @@ internal class StatisticsApiTest {
             .extract().jsonPath()
 
         assertThat(weekdays.getList<Any>("$")).hasSize(7)
-        assertThat(weekdays.getLong("[2].plays")).isEqualTo(3L) // mercredi (ISO 3)
-        assertThat(weekdays.getLong("[3].plays")).isEqualTo(3L) // jeudi
-        assertThat(weekdays.getLong("[4].plays")).isEqualTo(2L) // vendredi
-        assertThat(weekdays.getLong("[0].plays")).isEqualTo(0L) // lundi comblé à zéro
+        assertThat(weekdays.getLong("[2].plays")).isEqualTo(3L)
+        assertThat(weekdays.getLong("[3].plays")).isEqualTo(3L)
+        assertThat(weekdays.getLong("[4].plays")).isEqualTo(2L)
+        assertThat(weekdays.getLong("[0].plays")).isEqualTo(0L)
     }
 
     @Test
@@ -186,7 +173,7 @@ internal class StatisticsApiTest {
             .extract().jsonPath()
 
         assertThat(hours.getList<Any>("$")).hasSize(24)
-        assertThat(hours.getLong("[14].plays")).isEqualTo(6L) // 12h UTC = 14h Paris en été
+        assertThat(hours.getLong("[14].plays")).isEqualTo(6L)
         assertThat(hours.getLong("[20].plays")).isEqualTo(1L)
         assertThat(hours.getLong("[21].plays")).isEqualTo(1L)
         assertThat(hours.getLong("[0].plays")).isEqualTo(0L)
@@ -218,7 +205,7 @@ internal class StatisticsApiTest {
         assertThat(overTime.getString("granularity")).isEqualTo("MONTH")
         assertThat(overTime.getString("points[0].bucketStart")).startsWith("2020-06-01T00:00")
         assertThat(overTime.getLong("points[0].plays")).isEqualTo(8L)
-        assertThat(overTime.getLong("points[1].plays")).isEqualTo(0L) // mois vide comblé
+        assertThat(overTime.getLong("points[1].plays")).isEqualTo(0L)
     }
 
     @Test
@@ -236,7 +223,6 @@ internal class StatisticsApiTest {
     @Test
     @TestSecurity(user = "bob", roles = ["user"])
     fun `now playing returns the in-memory sessions`() {
-        // Poller désactivé en test : la liste est vide mais l'endpoint répond
         RestAssured.given()
             .`when`().get("/api/statistics/now-playing")
             .then().statusCode(Response.Status.OK.statusCode)

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/StatisticsImportTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/StatisticsImportTest.kt
@@ -61,21 +61,18 @@ internal class StatisticsImportTest {
         runImportJob().body("status", equalTo("SUCCESS"))
 
         val sessions = importedSessions()
-        // 4 entrées dans la fixture : l'audio et la session < 120 s sont ignorées
         assertThat(sessions).hasSize(2)
 
         val episode = sessions.single { it.mediaType == MediaType.EPISODE }
         assertThat(episode.itemId).isEqualTo("ep-1")
         assertThat(episode.itemName).isEqualTo("Épisode 2")
         assertThat(episode.seriesId).isEqualTo("series-1")
-        // Nom de série issu de jf_library_episodes, sans le suffixe [tvdbid-...]
         assertThat(episode.seriesName).isEqualTo("Funboys")
         assertThat(episode.seasonNumber).isEqualTo(1)
         assertThat(episode.episodeNumber).isEqualTo(2)
         assertThat(episode.userName).isEqualTo("oknozor")
         assertThat(episode.playDurationSeconds).isEqualTo(1300)
         assertThat(episode.runtimeSeconds).isEqualTo(1445)
-        // 1300/1445 ≈ 90 % >= seuil de 85 % : complété
         assertThat(episode.completed).isTrue()
         assertThat(episode.platform).isEqualTo("WEB")
         assertThat(episode.importKey).isEqualTo("import-key-episode")
@@ -84,12 +81,10 @@ internal class StatisticsImportTest {
         val movie = sessions.single { it.mediaType == MediaType.MOVIE }
         assertThat(movie.itemId).isEqualTo("movie-1")
         assertThat(movie.runtimeSeconds).isEqualTo(4752)
-        // 3000/4752 ≈ 63 % : non complété
         assertThat(movie.completed).isFalse()
         assertThat(movie.progressPercent).isEqualByComparingTo(BigDecimal("63.13"))
         assertThat(movie.platform).isEqualTo("ANDROID_TV")
 
-        // Rejouer le même backup ne crée aucun doublon (dédup sur import_key)
         stageFixture()
         runImportJob().body("status", equalTo("SUCCESS"))
         assertThat(importedSessions()).hasSize(2)
@@ -115,7 +110,6 @@ internal class StatisticsImportTest {
             .then().statusCode(Response.Status.ACCEPTED.statusCode)
             .body("jobIdentity", equalTo("jellystat-import"))
 
-        // L'import tourne en arrière-plan : le fichier stagé est supprimé en fin de succès
         awaitUntil { Files.notExists(Path.of(stagingPath)) && importedSessions().size == 2 }
         assertThat(importedSessions()).hasSize(2)
     }

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/StatsTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/StatsTest.kt
@@ -27,7 +27,6 @@ internal class StatsTest {
 
     @BeforeEach
     fun setUp() {
-        // Other tests may have persisted snapshots: remove them so stats are computed live from the stubs
         VertxContextSupport.subscribeAndAwait {
             Panache.withTransaction { StatsSnapshotEntity.deleteAll() }
         }
@@ -48,8 +47,6 @@ internal class StatsTest {
                 )
             )
         )
-        // Radarr and Sonarr share the same WireMock: both clients see the same mounts,
-        // which the dedupe-by-path aggregation must collapse to a single disk
         wireMock.register(
             get(urlPathEqualTo("/api/v3/diskspace")).willReturn(
                 okJson("""[{"path": "/data", "label": "data", "freeSpace": 500, "totalSpace": 2000}]""")

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/SubtitleNotificationsTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/SubtitleNotificationsTest.kt
@@ -68,7 +68,6 @@ internal class SubtitleNotificationsTest {
 
     @Test
     fun `should thread movie subtitle notification under movie download notification`() {
-        // 1. Radarr notifies movie downloaded
         RestAssured.given().contentType(ContentType.JSON)
             .body(radarrNotification(movieId = 900, title = "Interstellar", year = 2014))
             .header("X-Api-Key", "secureapikey")
@@ -77,7 +76,6 @@ internal class SubtitleNotificationsTest {
 
         val movieEventId = synapseTestClient.getLastMessageEvent(mediaRoomId).get("event_id").asText()
 
-        // 2. Bazarr notifies subtitle downloaded for same movie
         RestAssured.given().contentType(ContentType.JSON)
             .body(bazarrNotification("Interstellar (2014) : French subtitles downloaded from opensubtitles with a score of 95%."))
             .header("X-Api-Key", "secureapikey")
@@ -93,7 +91,6 @@ internal class SubtitleNotificationsTest {
 
     @Test
     fun `should thread series subtitle notification under episode download notification`() {
-        // 1. Sonarr notifies episode downloaded
         RestAssured.given().contentType(ContentType.JSON)
             .body(sonarrNotification(seriesId = 901, title = "Breaking Bad", year = 2008, episodeNumber = 1))
             .header("X-Api-Key", "secureapikey")
@@ -102,7 +99,6 @@ internal class SubtitleNotificationsTest {
 
         val seriesEventId = synapseTestClient.getLastMessageEvent(mediaRoomId).get("event_id").asText()
 
-        // 2. Bazarr notifies subtitle downloaded for same series
         RestAssured.given().contentType(ContentType.JSON)
             .body(bazarrNotification("Breaking Bad (2008) - S01E01 - Pilot : French subtitles downloaded from opensubtitles with a score of 90%."))
             .header("X-Api-Key", "secureapikey")

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/TimelineTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/TimelineTest.kt
@@ -39,7 +39,6 @@ internal class TimelineTest {
 
         wireMock.resetMappings()
         wireMock.resetRequests()
-        // Radarr and Sonarr share the same WireMock: disambiguate /history/since by query param
         wireMock.register(
             get(urlPathEqualTo("/api/v3/history/since"))
                 .withQueryParam("includeMovie", equalTo("true"))
@@ -85,7 +84,6 @@ internal class TimelineTest {
                     )
                 )
         )
-        // Lidarr est sur /api/v1 : pas de collision avec les stubs /api/v3 de Radarr/Sonarr
         wireMock.register(
             get(urlPathEqualTo("/api/v1/history/since")).willReturn(
                 okJson(
@@ -207,7 +205,6 @@ internal class TimelineTest {
         runJob("bazarr-downloads-sync")
 
         val items = getTimeline().getList<Map<String, Any>>("items")
-        // The action=0 episode item must be filtered out
         assertThat(items).hasSize(2)
         assertThat(items.map { it["eventType"] }).containsOnly("subtitles_downloaded")
         assertThat(items.map { it["title"] }).containsExactlyInAnyOrder("The Bear", "Dune")
@@ -263,7 +260,6 @@ internal class TimelineTest {
         assertThat(firstPage.getLong("totalCount")).isEqualTo(3)
         assertThat(firstPage.getInt("totalPages")).isEqualTo(3)
 
-        // Movie and first episode are from yesterday, second episode is older and must come last
         val lastPage = getTimeline(page = 2, pageSize = 1)
         val lastItem = lastPage.getList<Map<String, Any>>("items").first()
         assertThat(lastItem["title"]).isEqualTo("The Bear")

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/WeeklyReportNotificationsTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/WeeklyReportNotificationsTest.kt
@@ -36,8 +36,6 @@ internal class WeeklyReportNotificationsTest {
         mediaRoomId = synapseTestClient.createRoom("media-${System.nanoTime()}")
         roomProvider.media = mediaRoomId
         wireMock.resetMappings()
-        // Le rapport agrège playback_session sur 7 jours glissants : purge pour que
-        // les sessions seedées par les autres classes de test ne polluent pas les tops
         PlaybackSessionSeed.deleteAll()
     }
 

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/config/CleanupSeed.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/config/CleanupSeed.kt
@@ -10,7 +10,6 @@ import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.UUID
 
-/** Seed des tables cleanup_* pour les tests IT (campagnes, candidats, protections, suggestions). */
 internal object CleanupSeed {
 
     const val GB = 1_000_000_000L

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/it/config/PlaybackSessionSeed.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/it/config/PlaybackSessionSeed.kt
@@ -9,7 +9,6 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 
-/** Seed de playback_session pour les tests IT (base partagée : utiliser des users/médias identifiables). */
 internal object PlaybackSessionSeed {
 
     fun insertSession(

--- a/app/src/test/kotlin/org/hoohoot/homelab/manager/statistics/SessionTrackerTest.kt
+++ b/app/src/test/kotlin/org/hoohoot/homelab/manager/statistics/SessionTrackerTest.kt
@@ -26,7 +26,7 @@ internal class SessionTrackerTest {
         mediaType: MediaType = MediaType.MOVIE,
         isPaused: Boolean = false,
         positionTicks: Long? = null,
-        runTimeTicks: Long? = 36_000_000_000L, // 1h
+        runTimeTicks: Long? = 36_000_000_000L,
     ) = ActiveSession(
         userId = userId,
         userName = userName,
@@ -69,7 +69,6 @@ internal class SessionTrackerTest {
     fun `le temps de pause est deduit de la duree visionnee`() {
         tracker.onSnapshot(listOf(session()), t0)
         tracker.onSnapshot(listOf(session()), t0.plusSeconds(120))
-        // 2 ticks en pause : 120 s de pause accumulée
         tracker.onSnapshot(listOf(session(isPaused = true)), t0.plusSeconds(180))
         tracker.onSnapshot(listOf(session(isPaused = true)), t0.plusSeconds(240))
         tracker.onSnapshot(listOf(session()), t0.plusSeconds(300))
@@ -80,7 +79,7 @@ internal class SessionTrackerTest {
 
     @Test
     fun `la progression et la completion sont calculees depuis les ticks`() {
-        val almostDone = session(positionTicks = 33_000_000_000L) // 55 min sur 1h
+        val almostDone = session(positionTicks = 33_000_000_000L)
         tracker.onSnapshot(listOf(almostDone), t0)
         tracker.onSnapshot(listOf(almostDone), t0.plusSeconds(300))
         val finished = tracker.onSnapshot(emptyList(), t0.plusSeconds(315))
@@ -105,13 +104,11 @@ internal class SessionTrackerTest {
     fun `un trou de polling superieur au timeout cloture l'ancienne session et en demarre une nouvelle`() {
         tracker.onSnapshot(listOf(session()), t0)
         tracker.onSnapshot(listOf(session()), t0.plusSeconds(300))
-        // Jellyfin injoignable pendant 20 min, la même lecture est toujours en cours au retour
         val finished = tracker.onSnapshot(listOf(session()), t0.plusSeconds(1500))
 
         assertThat(finished).hasSize(1)
         assertThat(finished.single().playDurationSeconds).isEqualTo(300)
 
-        // La nouvelle session démarre au retour du polling
         tracker.onSnapshot(listOf(session()), t0.plusSeconds(1800))
         val second = tracker.onSnapshot(emptyList(), t0.plusSeconds(1815))
         assertThat(second.single().playDurationSeconds).isEqualTo(300)

--- a/operator/src/main/kotlin/org/hoohoot/homelab/manager/operator/ApplicationSyncService.kt
+++ b/operator/src/main/kotlin/org/hoohoot/homelab/manager/operator/ApplicationSyncService.kt
@@ -8,7 +8,6 @@ import org.eclipse.microprofile.rest.client.inject.RestClient
 @ApplicationScoped
 class ApplicationSyncService(@param:RestClient private val api: ManagerApiClient) {
 
-    /** Réconciliation complète : upsert de toutes les routes désirées, suppression des apps managées orphelines */
     fun syncAll(desired: List<DesiredApplication>) {
         val managed = listManaged()
         val desiredByExternalId = desired.associateBy { it.externalId }
@@ -23,12 +22,10 @@ class ApplicationSyncService(@param:RestClient private val api: ManagerApiClient
             }
     }
 
-    /** Upsert d'une seule route (chemin reconciler) */
     fun upsert(desired: DesiredApplication) {
         upsert(desired, listManaged()[desired.externalId])
     }
 
-    /** Supprime l'app correspondant à la route si (et seulement si) elle est managée par l'opérateur */
     fun deleteIfManaged(externalId: String) {
         val existing = listManaged()[externalId] ?: return
         Log.info("Deleting managed application '${existing.name}' ($externalId)")
@@ -57,9 +54,6 @@ class ApplicationSyncService(@param:RestClient private val api: ManagerApiClient
     private fun DesiredApplication.toRequest() =
         ApplicationRequest(name, category, description, url, requiresVpn, MANAGED_BY, externalId, logoUrl)
 
-    // logoSourceUrl : un logo uploadé à la main a une source nulle, donc pas de drift tant que
-    // le CRD ne déclare pas de logo-url ; un téléchargement échoué garde l'ancienne source et
-    // sera retenté au prochain sweep
     private fun ApplicationDto.hasDriftedFrom(desired: DesiredApplication): Boolean =
         name != desired.name ||
             category != desired.category ||

--- a/operator/src/main/kotlin/org/hoohoot/homelab/manager/operator/FullSyncJob.kt
+++ b/operator/src/main/kotlin/org/hoohoot/homelab/manager/operator/FullSyncJob.kt
@@ -8,10 +8,6 @@ import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.event.Observes
 
-/**
- * Sweep périodique : source de vérité pour les routes supprimées, que le reconciler
- * ne voit pas (pas de finalizer sur des ressources non possédées).
- */
 @ApplicationScoped
 class FullSyncJob(
     private val client: KubernetesClient,

--- a/operator/src/main/kotlin/org/hoohoot/homelab/manager/operator/HttpRouteMapper.kt
+++ b/operator/src/main/kotlin/org/hoohoot/homelab/manager/operator/HttpRouteMapper.kt
@@ -20,7 +20,6 @@ const val DEFAULT_DESCRIPTION = "Managed by homelab-manager-operator"
 @ApplicationScoped
 class HttpRouteMapper(private val config: OperatorConfig) {
 
-    /** Retourne null si la route n'est pas éligible (non annotée enabled=true ou URL indéterminable) */
     fun map(route: HTTPRoute): DesiredApplication? {
         val annotations = route.metadata?.annotations.orEmpty()
         val prefix = config.annotationPrefix()

--- a/operator/src/main/kotlin/org/hoohoot/homelab/manager/operator/HttpRouteReconciler.kt
+++ b/operator/src/main/kotlin/org/hoohoot/homelab/manager/operator/HttpRouteReconciler.kt
@@ -6,11 +6,6 @@ import io.javaoperatorsdk.operator.api.reconciler.Reconciler
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl
 import jakarta.enterprise.context.ApplicationScoped
 
-/**
- * Pas de Cleaner/finalizer : les HTTPRoute appartiennent à d'autres outils (Flux, Helm),
- * un finalizer bloquerait leur suppression si l'opérateur est down. Les routes supprimées
- * sont rattrapées par le sweep périodique de [FullSyncJob].
- */
 @ApplicationScoped
 class HttpRouteReconciler(
     private val mapper: HttpRouteMapper,

--- a/operator/src/main/kotlin/org/hoohoot/homelab/manager/operator/OperatorConfig.kt
+++ b/operator/src/main/kotlin/org/hoohoot/homelab/manager/operator/OperatorConfig.kt
@@ -5,7 +5,6 @@ import io.smallrye.config.WithDefault
 
 @ConfigMapping(prefix = "homelab-operator")
 interface OperatorConfig {
-    /** Noms des gateways dont les routes nécessitent le VPN */
     @WithDefault("internal")
     fun vpnGateways(): Set<String>
 
@@ -15,7 +14,6 @@ interface OperatorConfig {
     @WithDefault("Uncategorized")
     fun defaultCategory(): String
 
-    /** Intervalle du sweep complet (consommé par @Scheduled) */
     @WithDefault("5m")
     fun syncInterval(): String
 

--- a/operator/src/test/kotlin/org/hoohoot/homelab/manager/operator/ApplicationSyncServiceTest.kt
+++ b/operator/src/test/kotlin/org/hoohoot/homelab/manager/operator/ApplicationSyncServiceTest.kt
@@ -171,7 +171,6 @@ internal class ApplicationSyncServiceTest {
 
     @Test
     fun `does not consider a manually uploaded logo as drift`() {
-        // hasLogo true mais logoSourceUrl null : logo posé à la main, la route ne déclare pas de logo-url
         stubList(managedJellyfin.replace("\"hasLogo\": false", "\"hasLogo\": true"))
 
         syncService.syncAll(listOf(desiredJellyfin))


### PR DESCRIPTION
## Quoi

Nettoyage agressif des commentaires : **392 lignes supprimées sur 116 fichiers**, seuls **22 commentaires conservés**.

## Pourquoi

Ne garder que les commentaires **vraiment** nécessaires — ceux que le code ne peut pas rendre auto-descriptifs. En pratique : uniquement les *pièges purs*, c.-à-d. les comportements surprenants d'un système ou d'une lib externe où le code naïf serait faux.

Tout le reste est retiré : KDoc de rôle, justifications de design, rationale métier, intent et labels de test.

## Ce qui est conservé (22 commentaires)

| Catégorie | Exemples |
|---|---|
| Bugs de lib | `persist(emptyList)` crash "The Uni set is empty" |
| APIs externes non intuitives | Authentik renvoie `0`/`next=0` (pas `null`) ; Jellyfin incohérent sur la casse des `ProviderIds` ; Prometheus renvoie la valeur en string ; Matrix suffixe l'emoji d'un variation selector |
| Séquencement imposé | Sonarr : unmonitor avant suppression ; grab non-idempotent = double téléchargement |
| Pièges framework | contexte Vertx safe requis par Hibernate Reactive ; `readEntity` sur l'event loop → `BlockingNotAllowedException` ; `abortWith` sinon challenge OIDC ; Jackson strippe le préfixe `is` |
| Sécurité (anti-régression) | titres jamais interprétés comme HTML ; alias SQL pilotés par enum = pas d'injection |
| Données réelles vérifiées | `NowPlayingItemId` pointe la série ; suffixes `[tvdbid-...]` dans les backups |

## À noter pour le reviewer

- Aucune chaîne, URL ou annotation n'a été modifiée — que des suppressions de commentaires.
- `BUILD SUCCESS` vérifié (compilation principale + tests).
- Le retrait supprime beaucoup de "pourquoi" métier de bonne qualité : c'était un choix explicite. Le `git diff` permet de récupérer une catégorie si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)